### PR TITLE
chore: Add typecheck command to all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "turbo dev",
     "fix": "biome check --write --unsafe .",
     "prepare": "husky",
-    "test": "turbo test"
+    "test": "turbo test",
+    "typecheck": "turbo typecheck"
   },
   "devDependencies": {
     "@biomejs/biome": "catalog:",

--- a/packages/cli-bundle/package.json
+++ b/packages/cli-bundle/package.json
@@ -7,7 +7,8 @@
     "build": "rollup -c",
     "build:rollup-wasm": "cd src/stubs/rollup && npm install --ignore-scripts && npm run build:wasm",
     "build:viewer-resource": "tsx scripts/build-viewer-resource.ts",
-    "dev": "rollup -c -w --no-watch.clearScreen"
+    "dev": "rollup -c -w --no-watch.clearScreen",
+    "typecheck": "tsc --noEmit"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/packages/theme-registry/package.json
+++ b/packages/theme-registry/package.json
@@ -8,6 +8,9 @@
     ".": "./src/index.ts",
     "./*": "./src/*.ts"
   },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
   "devDependencies": {
     "@andrewbranch/untar.js": "catalog:",
     "@types/semver": "catalog:",
@@ -15,6 +18,7 @@
     "fflate": "catalog:",
     "lightningcss-wasm": "catalog:",
     "outvariant": "catalog:",
-    "semver": "catalog:"
+    "semver": "catalog:",
+    "vite": "catalog:"
   }
 }

--- a/packages/theme-registry/src/css-bundler.ts
+++ b/packages/theme-registry/src/css-bundler.ts
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 import init, * as lightningCss from 'lightningcss-wasm';
 import wasmUrl from 'lightningcss-wasm/lightningcss_node.wasm?url';
 

--- a/packages/theme-registry/tsconfig.json
+++ b/packages/theme-registry/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@v/config/tsconfig.app.json",
+  "include": ["src"]
+}

--- a/packages/tiptap-extensions/package.json
+++ b/packages/tiptap-extensions/package.json
@@ -9,7 +9,8 @@
     "./*": "./src/*.ts"
   },
   "scripts": {
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@tiptap/core": "catalog:",

--- a/packages/tiptap-extensions/tsconfig.json
+++ b/packages/tiptap-extensions/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@v/config/tsconfig.app.json",
+  "include": ["src"]
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,6 +9,9 @@
     "./*.css": "./src/*.css",
     "./*": "./src/*.tsx"
   },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
   "devDependencies": {
     "@floating-ui/react-dom": "catalog:",
     "@types/react": "catalog:",

--- a/packages/viola/package.json
+++ b/packages/viola/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite --host",
     "build": "tsc -b && vite build",
-    "preview": "vite preview --host"
+    "preview": "vite preview --host",
+    "typecheck": "tsc -b"
   },
   "devDependencies": {
     "@codemirror/autocomplete": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,9 @@ importers:
       semver:
         specifier: 'catalog:'
         version: 7.7.1
+      vite:
+        specifier: 'catalog:'
+        version: 6.3.5(patch_hash=f2bda8a745602e0e18f050ccc7c978c24e26450f353eaf97ffd58bc667779785)(@types/node@22.10.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1)
 
   packages/tiptap-extensions:
     dependencies:
@@ -12954,10 +12957,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
-  fdir@6.4.4(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
-
   fdir@6.4.4(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -16658,8 +16657,8 @@ snapshots:
   vite@6.3.5(patch_hash=f2bda8a745602e0e18f050ccc7c978c24e26450f353eaf97ffd58bc667779785)(@types/node@22.10.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1):
     dependencies:
       esbuild: 0.25.0
-      fdir: 6.4.4(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.4.4(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.3
       rollup: 4.57.1
       tinyglobby: 0.2.14

--- a/turbo.json
+++ b/turbo.json
@@ -42,6 +42,11 @@
     "test": {
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["coverage/**"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
## Summary

- 各パッケージに `typecheck` スクリプト (`tsc --noEmit` または `tsc -b`) を追加
- `turbo.json` の tasks に `typecheck` を追加し、`^build` への依存関係を設定
- ルート `package.json` に `pnpm typecheck` を追加
- `theme-registry` と `tiptap-extensions` に `tsconfig.json` を追加
- `theme-registry/src/css-bundler.ts` の Vite 用 `?url` インポートが型チェックを通るよう `/// <reference types="vite/client" />` を追加し、 `vite` を devDependency に追加

## Test plan

- [x] `pnpm typecheck` がすべてのパッケージで成功すること
- [x] `pnpm build` が引き続き成功すること
- [ ] CI 上での挙動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)