### PR TITLE
ci: Add test and typecheck workflow for PRs and merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: ci
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  merge_group:
+    types: [checks_requested]
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: vivliostyle/vivliostyle.pub/.github/actions/setup@main
+      - run: pnpm test
+
+  typecheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: vivliostyle/vivliostyle.pub/.github/actions/setup@main
+      - run: pnpm typecheck

--- a/packages/tiptap-extensions/package.json
+++ b/packages/tiptap-extensions/package.json
@@ -9,7 +9,7 @@
     "./*": "./src/*.ts"
   },
   "scripts": {
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {


### PR DESCRIPTION
Add a CI workflow that runs tests and type checking on pull requests and the merge queue.

- Adds `.github/workflows/ci.yml` with jobs for running tests and typechecks across all packages
- Triggers on pull requests and merge group events to ensure code quality before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)