### PR TITLE
Rename 'Bibliography' menu to 'Title and metadata'

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can try the development version of Vivliostyle Pub at: https://alpha.vivlios
 4. You can start typing in the editor. To insert a heading, type `# Heading` and press Enter. To insert a paragraph, just type your text and press Enter.
 5. You can check the page preview in the right pane.
 6. Click "Vivliostyle Pub" menu in the top left corner to open the submenu:
-    - Bibliography
+    - Title and metadata
       - Book metadata settings such as title and author
       - Table of Contents settings
     - Customize theme

--- a/packages/viola/src/components/panes/pane.bibliography.tsx
+++ b/packages/viola/src/components/panes/pane.bibliography.tsx
@@ -40,7 +40,7 @@ declare global {
 }
 
 export const Pane = createPane<BibliographyPaneProperty>({
-  title: () => 'Bibliography',
+  title: () => 'Title and metadata',
   content: (props) => (
     <ScrollOverflow>
       <PaneContainer>

--- a/packages/viola/src/components/side-menu.tsx
+++ b/packages/viola/src/components/side-menu.tsx
@@ -137,7 +137,7 @@ function ProjectDropdownMenu({ children }: React.PropsWithChildren) {
         <DropdownMenuItem asChild>
           <Link to="/bibliography">
             <BookOpen />
-            <span>Bibliography</span>
+            <span>Title and metadata</span>
           </Link>
         </DropdownMenuItem>
         <DropdownMenuItem asChild>


### PR DESCRIPTION
Renames the sidebar menu item from **Bibliography** to **Title and metadata** to better reflect the pane's actual purpose — managing book title, author, and table of contents metadata.

## Changes

- Updated menu label in `side-menu.tsx`
- Updated pane label in `pane.bibliography.tsx`
- Updated documentation in `README.md`

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)