### PR TITLE
fix: Restore cross-origin-isolated in sandbox iframes

### DIFF
--- a/packages/cli-bundle/src/stubs/install-process-global.ts
+++ b/packages/cli-bundle/src/stubs/install-process-global.ts
@@ -8,10 +8,21 @@
 // step that reads `globalThis.process`, and `global-this.ts`'s assignment
 // happens AFTER that init runs. Importing this file from `src/index.ts` first
 // schedules the `process` global before unenv's env probe.
+//
+// Vite injects a stub `globalThis.process = { env: { NODE_ENV, ... } }` into
+// worker contexts for `process.env.*` access. We need to replace that stub
+// with unenv's full polyfill (so `platform`, `cwd()`, etc. exist) while
+// preserving any `env` entries the bundler/runtime set up.
 import unenvProcess from 'unenv/node/process';
 
-const root = new Function('return globalThis')() as typeof globalThis;
+const root = new Function('return globalThis')() as {
+  process?: { env?: Record<string, unknown> };
+};
 
-if (!root.process) {
+if (root.process !== unenvProcess) {
+  const existingEnv = root.process?.env;
   root.process = unenvProcess;
+  if (existingEnv && typeof existingEnv === 'object') {
+    Object.assign(unenvProcess.env, existingEnv);
+  }
 }

--- a/packages/viola/src/libs/generate-id.ts
+++ b/packages/viola/src/libs/generate-id.ts
@@ -8,9 +8,12 @@ export function generateId<T extends string>(): T {
 }
 
 // `projectId` is used in the sandbox iframe subdomain as `sandbox-${projectId}`.
-// Chromium silently drops cross-origin-isolated when the `projectId` portion
-// contains characters outside lowercase alphanumerics (notably `_` and
-// case-folded uppercase), breaking `SharedArrayBuffer` in the CLI worker.
+// Keep it safe for use inside a single DNS label: lowercase letters, digits,
+// and interior `-` are valid, while characters such as `_`, uppercase, and
+// other non-DNS-label characters can cause Chromium to drop
+// `cross-origin-isolated`, breaking `SharedArrayBuffer` in the CLI worker.
+// We intentionally generate the stricter lowercase-alphanumeric subset here
+// for maximum compatibility.
 // Length 25 keeps ~129 bits of entropy against this 36-char alphabet
 // (≥ nanoid's default ~126).
 const projectIdNanoid = customAlphabet(

--- a/packages/viola/src/libs/generate-id.ts
+++ b/packages/viola/src/libs/generate-id.ts
@@ -7,11 +7,12 @@ export function generateId<T extends string>(): T {
   return nanoid() as T;
 }
 
-// `projectId` is used as a host label in the sandbox iframe subdomain,
-// where Chromium silently drops cross-origin-isolated for any character
-// outside lowercase alphanumerics (notably `_` and case-folded uppercase),
-// breaking `SharedArrayBuffer` in the CLI worker. Length 25 keeps ~129 bits
-// of entropy against this 36-char alphabet (≥ nanoid's default ~126).
+// `projectId` is used in the sandbox iframe subdomain as `sandbox-${projectId}`.
+// Chromium silently drops cross-origin-isolated when the `projectId` portion
+// contains characters outside lowercase alphanumerics (notably `_` and
+// case-folded uppercase), breaking `SharedArrayBuffer` in the CLI worker.
+// Length 25 keeps ~129 bits of entropy against this 36-char alphabet
+// (≥ nanoid's default ~126).
 const projectIdNanoid = customAlphabet(
   'abcdefghijklmnopqrstuvwxyz0123456789',
   25,

--- a/packages/viola/src/libs/generate-id.ts
+++ b/packages/viola/src/libs/generate-id.ts
@@ -7,6 +7,20 @@ export function generateId<T extends string>(): T {
   return nanoid() as T;
 }
 
+// `projectId` is used as a host label in the sandbox iframe subdomain,
+// where Chromium silently drops cross-origin-isolated for any character
+// outside lowercase alphanumerics (notably `_` and case-folded uppercase),
+// breaking `SharedArrayBuffer` in the CLI worker. Length 25 keeps ~129 bits
+// of entropy against this 36-char alphabet (≥ nanoid's default ~126).
+const projectIdNanoid = customAlphabet(
+  'abcdefghijklmnopqrstuvwxyz0123456789',
+  25,
+);
+
+export function generateProjectId<T extends string>(): T {
+  return projectIdNanoid() as T;
+}
+
 const getRandomAlphanumeric = customAlphabet(alphanumeric);
 
 export function generateRandomName(): string {

--- a/packages/viola/src/stores/proxies/project.ts
+++ b/packages/viola/src/stores/proxies/project.ts
@@ -21,7 +21,7 @@ function detectBrowserLanguage(): string {
 declare const projectIdBrand: unique symbol;
 export type ProjectId = string & { [projectIdBrand]: never };
 
-export const draftProjectId: ProjectId = '__draft' as ProjectId;
+export const draftProjectId: ProjectId = 'draft' as ProjectId;
 
 const initialBibliographyState = {
   title: '',


### PR DESCRIPTION
Restores `cross-origin-isolated` in sandbox iframes, which broke `SharedArrayBuffer` access in the CLI worker (Rolldown WASI).

## Changes

- **`generate-id.ts`**: Add `generateProjectId()` using a lowercase alphanumeric-only alphabet (`[a-z0-9]`, length 25). Chromium silently drops cross-origin-isolated headers for subdomains containing `_` or uppercase characters — `__draft` was the culprit triggering this.
- **`project.ts`**: Rename `draftProjectId` from `'__draft'` to `'draft'` to avoid the leading underscores that break Chromium subdomain header handling.
- **`install-process-global.ts`**: Preserve Vite's injected `process.env` entries (e.g. `NODE_ENV`) when replacing the stub with unenv's full polyfill, rather than wiping them. Also fixes the guard to always replace a partial stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)