### PR TITLE
feat(viola/editor): Persist editor state with y-indexeddb

### DIFF
--- a/packages/viola/package.json
+++ b/packages/viola/package.json
@@ -50,7 +50,6 @@
     "comlink": "catalog:",
     "dompurify": "catalog:",
     "html-react-parser": "catalog:",
-    "idb": "8.0.3",
     "nanoid": "catalog:",
     "nanoid-dictionary": "catalog:",
     "outvariant": "catalog:",

--- a/packages/viola/src/libs/editor.ts
+++ b/packages/viola/src/libs/editor.ts
@@ -1,8 +1,9 @@
 import { Editor, type Extensions } from '@tiptap/core';
+import { Collaboration } from '@tiptap/extension-collaboration';
 import { Placeholder } from '@tiptap/extensions';
-import * as idb from 'idb';
 import { dirname, relative } from 'pathe';
 import { ref } from 'valtio';
+import { IndexeddbPersistence } from 'y-indexeddb';
 import * as Y from 'yjs';
 
 import { PubExtensions } from '@v/tiptap-extensions';
@@ -10,6 +11,7 @@ import { InlineTrigger } from '@v/tiptap-extensions/inline-trigger';
 import { debounce } from '../libs/debounce';
 import { $content, $sandbox } from '../stores/accessors';
 import type { ContentId } from '../stores/proxies/content';
+import type { ProjectId } from '../stores/proxies/project';
 import { SandboxFile } from '../stores/proxies/sandbox';
 import { createSandboxImageSaver } from './editor/image-saver';
 import { getAllTriggers, inlineMenuState } from './editor/inline-menu';
@@ -18,88 +20,16 @@ import { insertImageFiles } from './editor/insert-image';
 
 import './editor/inline-menu.media';
 
-// @ts-expect-error
-async function _setupPersistence({
-  doc,
-}: {
-  doc: Y.Doc;
-  contentId: ContentId;
-}): Promise<void> {
-  const preferredTrimSize = 500;
-  const storeName = 'update';
-  // @ts-expect-error
-  const origin = this as unknown;
-  const db = await idb.openDB('viola:editor', 1, {
-    upgrade(db) {
-      db.createObjectStore(storeName, { autoIncrement: true });
-    },
-  });
-
-  let dbRef = 0;
-  let dbSize = 0;
-  fetchUpdate(true);
-
-  async function fetchUpdate(init = false) {
-    const tx = db.transaction(storeName, 'readwrite');
-    const updates = await tx.store.getAll(IDBKeyRange.lowerBound(dbRef, false));
-    if (init) {
-      await tx.store.add(Y.encodeStateAsUpdate(doc));
-    }
-    Y.transact(
-      doc,
-      () => {
-        for (const update of updates) {
-          Y.applyUpdate(doc, update);
-        }
-      },
-      origin,
-      false,
-    );
-    const lastKey = (await tx.store.openKeyCursor(null, 'prev'))?.key;
-    dbRef = ((lastKey as number) ?? 0) + 1;
-    dbSize = await tx.store.count();
-    await tx.done;
-  }
-
-  const storeState = debounce(
-    async function storeState() {
-      await fetchUpdate();
-      if (dbSize >= preferredTrimSize) {
-        const tx = db.transaction(storeName, 'readwrite');
-        await tx.store.add(Y.encodeStateAsUpdate(doc));
-        await tx.store.delete(IDBKeyRange.upperBound(dbRef, true));
-        dbSize = await tx.store.count();
-        await tx.done;
-      }
-    },
-    1000,
-    { trailing: true },
-  );
-
-  function onUpdate(update: Uint8Array, _origin: unknown) {
-    if (origin === _origin) {
-      return;
-    }
-    const tr = db.transaction(storeName, 'readwrite');
-    tr.store.add(update);
-    if (++dbSize >= preferredTrimSize) {
-      storeState();
-    }
-  }
-
-  function onDestroy() {
-    doc.off('update', onUpdate);
-    doc.off('destroy', onDestroy);
-  }
-
-  doc.on('update', onUpdate);
-  doc.on('destroy', onDestroy);
-}
-
 const saveContent = debounce(
   async ({ editor, contentId }: { editor: Editor; contentId: ContentId }) => {
-    const $$content = $content.valueOrThrow();
-    const $$sandbox = $sandbox.valueOrThrow();
+    // Collaboration hydration (loading persisted Yjs state) can emit updates
+    // before the owning project becomes current, so bail out instead of
+    // throwing when no project/sandbox is active yet.
+    const $$content = $content.value();
+    const $$sandbox = $sandbox.value();
+    if (!$$content || !$$sandbox) {
+      return;
+    }
     const file = $$content.files.get(contentId);
     if (!file) {
       return;
@@ -119,12 +49,18 @@ const saveContent = debounce(
   { trailing: true },
 );
 
+function editorPersistenceKey(projectId: ProjectId, filename: string): string {
+  return `viola:editor:${projectId}:${filename}`;
+}
+
 export async function setupEditor({
+  projectId,
   contentId,
   filename,
   entryContext,
   initialFile,
 }: {
+  projectId: ProjectId;
   contentId: ContentId;
   filename?: string;
   entryContext?: string;
@@ -136,8 +72,13 @@ export async function setupEditor({
     basePath = undefined;
   }
 
-  // const doc = new Y.Doc();
-  // await setupPersistence({ doc, contentId });
+  const doc = new Y.Doc();
+  // Editor state is persisted to IndexedDB keyed by a stable project + file
+  // path. contentId is regenerated on every load, so it cannot serve as the
+  // persistence key.
+  const persistence = filename
+    ? new IndexeddbPersistence(editorPersistenceKey(projectId, filename), doc)
+    : undefined;
 
   const extensions = [
     PubExtensions.configure({
@@ -176,18 +117,39 @@ export async function setupEditor({
         inlineMenuState.coords = coords;
       },
     }),
-    // Collaboration.configure({
-    //   document: doc,
-    // }),
+    Collaboration.configure({
+      document: doc,
+    }),
   ] satisfies Extensions;
 
-  const markdown = await initialFile?.text();
-  return new Editor({
+  const editor = new Editor({
     extensions,
-    content: markdown?.trim(),
-    contentType: 'markdown',
     onUpdate: ({ editor }) => {
       saveContent({ editor, contentId });
     },
   });
+
+  editor.on('destroy', () => {
+    persistence?.destroy();
+    doc.destroy();
+  });
+
+  // Load any previously persisted state first, then seed from the on-disk
+  // markdown only when this file has no editor history yet (first open).
+  // Seeding emits no update so it neither re-writes the source file nor
+  // requires the project to be the current one yet.
+  if (persistence) {
+    await persistence.whenSynced;
+  }
+  if (doc.getXmlFragment('default').length === 0) {
+    const markdown = (await initialFile?.text())?.trim();
+    if (markdown) {
+      editor.commands.setContent(markdown, {
+        contentType: 'markdown',
+        emitUpdate: false,
+      });
+    }
+  }
+
+  return editor;
 }

--- a/packages/viola/src/stores/actions/content-file.ts
+++ b/packages/viola/src/stores/actions/content-file.ts
@@ -5,7 +5,7 @@ import { ref } from 'valtio';
 
 import { setupEditor } from '../../libs/editor';
 import { generateId, generateRandomName } from '../../libs/generate-id';
-import { $content, $sandbox, $ui } from '../accessors';
+import { $content, $project, $sandbox, $ui } from '../accessors';
 import type { ContentId } from '../proxies/content';
 import { SandboxFile } from '../proxies/sandbox';
 
@@ -18,6 +18,7 @@ export async function createContentFile({
 }): Promise<ContentId> {
   const $$content = $content.valueOrThrow();
   const $$sandbox = $sandbox.valueOrThrow();
+  const projectId = $project.valueOrThrow().projectId;
   const prevFile = insertAfter && $$content.files.get(insertAfter);
   const entryContext = $$sandbox.vivliostyleConfig.entryContext || '';
   const prevFileDir =
@@ -44,7 +45,9 @@ export async function createContentFile({
     format,
     filename,
     summary: '',
-    editor: ref(await setupEditor({ contentId, filename, entryContext })),
+    editor: ref(
+      await setupEditor({ projectId, contentId, filename, entryContext }),
+    ),
   });
   $$content.readingOrder.splice(index, 0, contentId);
   return contentId;

--- a/packages/viola/src/stores/proxies/project.ts
+++ b/packages/viola/src/stores/proxies/project.ts
@@ -145,6 +145,7 @@ export class Project {
       }
       const contentId = generateId<ContentId>();
       const editor = await setupEditor({
+        projectId: this.projectId,
         contentId,
         filename,
         entryContext,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -789,9 +789,6 @@ importers:
       html-react-parser:
         specifier: 'catalog:'
         version: 6.1.0(@types/react@19.2.14)(react@19.2.6)
-      idb:
-        specifier: 8.0.3
-        version: 8.0.3
       nanoid:
         specifier: 'catalog:'
         version: 5.1.11
@@ -4971,9 +4968,6 @@ packages:
 
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
-
-  idb@8.0.3:
-    resolution: {integrity: sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -12167,8 +12161,6 @@ snapshots:
       safer-buffer: 2.1.2
 
   idb@7.1.1: {}
-
-  idb@8.0.3: {}
 
   ieee754@1.2.1: {}
 


### PR DESCRIPTION
## Summary

Persist each content file's TipTap editor across reloads by binding it to a Yjs document and storing that document in IndexedDB via `y-indexeddb`. Until now the editor was reconstructed from the on-disk markdown on every load, so in-editor history (and any state not representable in markdown) was lost on refresh.

## Changes

- Bind each editor to a `Y.Doc` through the `@tiptap/extension-collaboration` extension and attach `IndexeddbPersistence` from `y-indexeddb`.
- Key the IndexedDB store by a stable `viola:editor:<projectId>:<filename>` name. `contentId` is regenerated on every load, so it cannot be used as the key; `filename` is stable and `projectId` disambiguates identical paths across projects.
- On open, load persisted state first (`await persistence.whenSynced`); seed from the on-disk markdown only when the document has no editor history yet (first open), using `setContent(md, { contentType: 'markdown', emitUpdate: false })` so seeding neither rewrites the source file nor requires the project to be current.
- Keep serializing edits back to markdown in OPFS for the Vivliostyle CLI build.
- Destroy the persistence and `Y.Doc` when the editor is destroyed.
- `saveContent` now bails out when no project/sandbox is current, because Collaboration hydration can emit updates before the owning project becomes active.
- Remove the disabled hand-rolled IndexedDB persistence and the now-unused `idb` dependency.

Editor data flow: `IndexedDB (Y.Doc)` is the editor's persistent state; OPFS markdown remains the build input and the first-open seed source.

## Call sites

`setupEditor` now takes `projectId`, passed from `Project.restoreProjectFromFileSystem` (`this.projectId`) and `createContentFile` (`$project.valueOrThrow().projectId`).

## Verification

- [ ] `pnpm typecheck` — green
- [ ] `pnpm check` — Biome lint/format green
- [ ] `pnpm test` — cli-bundle 7 + storage-providers 31 = 38 tests, all green
- [ ] `pnpm --filter @v/viola build` — succeeds
- [ ] Manual: edit a file, reload, and confirm the content is restored from IndexedDB
- [ ] Manual: create a fresh project and confirm the first open seeds from the template markdown
- [ ] Manual: confirm edits still propagate to the preview/build (markdown written to OPFS)

> [!NOTE]
> Browser behavior was not verified in CI: the dev server requires `secrets/` (HTTPS cert + `VITE_APP_HOSTNAME`), which is unavailable in the sandbox. The manual checks above should be run locally or against the PR preview.

## Known limitations

- Editing the raw markdown outside the rich editor (e.g. a future raw-source editor) would not feed back into the Y.Doc; on reload the persisted Y.Doc wins. The CodeMirror editor today is only used for CSS/theme, so content files are unaffected.
- Deleting or renaming a file does not yet purge its IndexedDB store. A renamed file re-seeds from its (preserved) markdown, so content survives but editor history does not.

https://claude.ai/code/session_01CEpiAaGXFGdFWUzHWFQngf

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEpiAaGXFGdFWUzHWFQngf)_