### PR TITLE
feat(viola/editor): Persist editor state with y-indexeddb

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,16 @@ Single-package and single-test invocations:
 
 The `secrets/` directory is gitignored, and agent sandboxes are configured to deny reads from it. Agents must not attempt to bypass that restriction.
 
+### Before starting the dev server
+
+Before running `pnpm dev` (or any other long-running server like `vite`/`wrangler dev`), always check whether the user already has one running. Examples of cheap checks:
+
+- `lsof -iTCP:5173 -sTCP:LISTEN` (or whichever port the server uses)
+- `ps -A | grep -E 'vite|wrangler'`
+- Ask the user if unsure.
+
+Spawning a second dev server on top of an existing one wastes the user's time, can cause port collisions, and may interfere with their in-progress browser session.
+
 ## Architecture
 
 ### Why this is unusual

--- a/packages/viola/package.json
+++ b/packages/viola/package.json
@@ -50,7 +50,6 @@
     "comlink": "catalog:",
     "dompurify": "catalog:",
     "html-react-parser": "catalog:",
-    "idb": "8.0.3",
     "nanoid": "catalog:",
     "nanoid-dictionary": "catalog:",
     "outvariant": "catalog:",

--- a/packages/viola/src/libs/editor.ts
+++ b/packages/viola/src/libs/editor.ts
@@ -17,6 +17,7 @@ import { createSandboxImageSaver } from './editor/image-saver';
 import { getAllTriggers, inlineMenuState } from './editor/inline-menu';
 import { insertExistingAsset } from './editor/insert-asset';
 import { insertImageFiles } from './editor/insert-image';
+import { YUndoCursorFix } from './editor/y-undo-cursor-fix';
 
 import './editor/inline-menu.media';
 
@@ -120,6 +121,7 @@ export async function setupEditor({
     Collaboration.configure({
       document: doc,
     }),
+    YUndoCursorFix,
   ] satisfies Extensions;
 
   const editor = new Editor({

--- a/packages/viola/src/libs/editor.ts
+++ b/packages/viola/src/libs/editor.ts
@@ -1,8 +1,9 @@
 import { Editor, type Extensions } from '@tiptap/core';
+import { Collaboration } from '@tiptap/extension-collaboration';
 import { Placeholder } from '@tiptap/extensions';
-import * as idb from 'idb';
 import { dirname, relative } from 'pathe';
 import { ref } from 'valtio';
+import { IndexeddbPersistence } from 'y-indexeddb';
 import * as Y from 'yjs';
 
 import { PubExtensions } from '@v/tiptap-extensions';
@@ -10,6 +11,7 @@ import { InlineTrigger } from '@v/tiptap-extensions/inline-trigger';
 import { debounce } from '../libs/debounce';
 import { $content, $sandbox } from '../stores/accessors';
 import type { ContentId } from '../stores/proxies/content';
+import type { ProjectId } from '../stores/proxies/project';
 import { SandboxFile } from '../stores/proxies/sandbox';
 import { createSandboxImageSaver } from './editor/image-saver';
 import { getAllTriggers, inlineMenuState } from './editor/inline-menu';
@@ -18,88 +20,16 @@ import { insertImageFiles } from './editor/insert-image';
 
 import './editor/inline-menu.media';
 
-// @ts-expect-error
-async function _setupPersistence({
-  doc,
-}: {
-  doc: Y.Doc;
-  contentId: ContentId;
-}): Promise<void> {
-  const preferredTrimSize = 500;
-  const storeName = 'update';
-  // @ts-expect-error
-  const origin = this as unknown;
-  const db = await idb.openDB('viola:editor', 1, {
-    upgrade(db) {
-      db.createObjectStore(storeName, { autoIncrement: true });
-    },
-  });
-
-  let dbRef = 0;
-  let dbSize = 0;
-  fetchUpdate(true);
-
-  async function fetchUpdate(init = false) {
-    const tx = db.transaction(storeName, 'readwrite');
-    const updates = await tx.store.getAll(IDBKeyRange.lowerBound(dbRef, false));
-    if (init) {
-      await tx.store.add(Y.encodeStateAsUpdate(doc));
-    }
-    Y.transact(
-      doc,
-      () => {
-        for (const update of updates) {
-          Y.applyUpdate(doc, update);
-        }
-      },
-      origin,
-      false,
-    );
-    const lastKey = (await tx.store.openKeyCursor(null, 'prev'))?.key;
-    dbRef = ((lastKey as number) ?? 0) + 1;
-    dbSize = await tx.store.count();
-    await tx.done;
-  }
-
-  const storeState = debounce(
-    async function storeState() {
-      await fetchUpdate();
-      if (dbSize >= preferredTrimSize) {
-        const tx = db.transaction(storeName, 'readwrite');
-        await tx.store.add(Y.encodeStateAsUpdate(doc));
-        await tx.store.delete(IDBKeyRange.upperBound(dbRef, true));
-        dbSize = await tx.store.count();
-        await tx.done;
-      }
-    },
-    1000,
-    { trailing: true },
-  );
-
-  function onUpdate(update: Uint8Array, _origin: unknown) {
-    if (origin === _origin) {
-      return;
-    }
-    const tr = db.transaction(storeName, 'readwrite');
-    tr.store.add(update);
-    if (++dbSize >= preferredTrimSize) {
-      storeState();
-    }
-  }
-
-  function onDestroy() {
-    doc.off('update', onUpdate);
-    doc.off('destroy', onDestroy);
-  }
-
-  doc.on('update', onUpdate);
-  doc.on('destroy', onDestroy);
-}
-
 const saveContent = debounce(
   async ({ editor, contentId }: { editor: Editor; contentId: ContentId }) => {
-    const $$content = $content.valueOrThrow();
-    const $$sandbox = $sandbox.valueOrThrow();
+    // Collaboration hydration (loading persisted Yjs state) can emit updates
+    // before the owning project becomes current, so bail out instead of
+    // throwing when no project/sandbox is active yet.
+    const $$content = $content.value();
+    const $$sandbox = $sandbox.value();
+    if (!$$content || !$$sandbox) {
+      return;
+    }
     const file = $$content.files.get(contentId);
     if (!file) {
       return;
@@ -119,12 +49,18 @@ const saveContent = debounce(
   { trailing: true },
 );
 
+function editorPersistenceKey(projectId: ProjectId, filename: string): string {
+  return `viola:editor:${projectId}:${filename}`;
+}
+
 export async function setupEditor({
+  projectId,
   contentId,
   filename,
   entryContext,
   initialFile,
 }: {
+  projectId: ProjectId;
   contentId: ContentId;
   filename?: string;
   entryContext?: string;
@@ -136,8 +72,13 @@ export async function setupEditor({
     basePath = undefined;
   }
 
-  // const doc = new Y.Doc();
-  // await setupPersistence({ doc, contentId });
+  const doc = new Y.Doc();
+  // Editor state is persisted to IndexedDB keyed by a stable project + file
+  // path. contentId is regenerated on every load, so it cannot serve as the
+  // persistence key.
+  const persistence = filename
+    ? new IndexeddbPersistence(editorPersistenceKey(projectId, filename), doc)
+    : undefined;
 
   const extensions = [
     PubExtensions.configure({
@@ -176,18 +117,39 @@ export async function setupEditor({
         inlineMenuState.coords = coords;
       },
     }),
-    // Collaboration.configure({
-    //   document: doc,
-    // }),
+    Collaboration.configure({
+      document: doc,
+    }),
   ] satisfies Extensions;
 
-  const markdown = await initialFile?.text();
-  return new Editor({
+  const editor = new Editor({
     extensions,
-    content: markdown?.trim(),
-    contentType: 'markdown',
     onUpdate: ({ editor }) => {
       saveContent({ editor, contentId });
     },
   });
+
+  editor.on('destroy', () => {
+    persistence?.destroy();
+    doc.destroy();
+  });
+
+  // Load any previously persisted state first, then seed from the on-disk
+  // markdown only when this file has no editor history yet (first open).
+  // Seeding emits no update so it neither re-writes the source file nor
+  // requires the project to be the current one yet.
+  if (persistence) {
+    await persistence.whenSynced;
+  }
+  if (doc.getXmlFragment('default').length === 0) {
+    const markdown = (await initialFile?.text())?.trim();
+    if (markdown) {
+      editor.commands.setContent(markdown, {
+        contentType: 'markdown',
+        emitUpdate: false,
+      });
+    }
+  }
+
+  return editor;
 }

--- a/packages/viola/src/libs/editor.ts
+++ b/packages/viola/src/libs/editor.ts
@@ -9,7 +9,7 @@ import * as Y from 'yjs';
 import { PubExtensions } from '@v/tiptap-extensions';
 import { InlineTrigger } from '@v/tiptap-extensions/inline-trigger';
 import { debounce } from '../libs/debounce';
-import { $content, $sandbox } from '../stores/accessors';
+import { $projects } from '../stores/accessors';
 import type { ContentId } from '../stores/proxies/content';
 import type { ProjectId } from '../stores/proxies/project';
 import { SandboxFile } from '../stores/proxies/sandbox';
@@ -20,35 +20,6 @@ import { insertImageFiles } from './editor/insert-image';
 import { YUndoCursorFix } from './editor/y-undo-cursor-fix';
 
 import './editor/inline-menu.media';
-
-const saveContent = debounce(
-  async ({ editor, contentId }: { editor: Editor; contentId: ContentId }) => {
-    // Collaboration hydration (loading persisted Yjs state) can emit updates
-    // before the owning project becomes current, so bail out instead of
-    // throwing when no project/sandbox is active yet.
-    const $$content = $content.value();
-    const $$sandbox = $sandbox.value();
-    if (!$$content || !$$sandbox) {
-      return;
-    }
-    const file = $$content.files.get(contentId);
-    if (!file) {
-      return;
-    }
-    file.summary =
-      editor
-        .getText({ blockSeparator: '\n' })
-        .split('\n')
-        .find((s) => s.trim())
-        ?.trim() || '';
-    const markdown = editor.getMarkdown();
-    $$sandbox.files[file.filename] = ref(
-      new SandboxFile('text/markdown', markdown),
-    );
-  },
-  1000,
-  { trailing: true },
-);
 
 function editorPersistenceKey(projectId: ProjectId, filename: string): string {
   return `viola:editor:${projectId}:${filename}`;
@@ -80,6 +51,35 @@ export async function setupEditor({
   const persistence = filename
     ? new IndexeddbPersistence(editorPersistenceKey(projectId, filename), doc)
     : undefined;
+
+  // Resolve the owning project via projectId rather than the current-project
+  // accessors so persisted-state hydration writes back to the right sandbox
+  // even when this project has not yet been made current.
+  const saveContent = debounce(
+    (editor: Editor) => {
+      const project = $projects.value[projectId];
+      const sandbox = project?.sandbox;
+      if (!project || !sandbox) {
+        return;
+      }
+      const file = project.content.files.get(contentId);
+      if (!file) {
+        return;
+      }
+      file.summary =
+        editor
+          .getText({ blockSeparator: '\n' })
+          .split('\n')
+          .find((s) => s.trim())
+          ?.trim() || '';
+      const markdown = editor.getMarkdown();
+      sandbox.files[file.filename] = ref(
+        new SandboxFile('text/markdown', markdown),
+      );
+    },
+    1000,
+    { trailing: true },
+  );
 
   const extensions = [
     PubExtensions.configure({
@@ -127,7 +127,7 @@ export async function setupEditor({
   const editor = new Editor({
     extensions,
     onUpdate: ({ editor }) => {
-      saveContent({ editor, contentId });
+      saveContent(editor);
     },
   });
 

--- a/packages/viola/src/libs/editor/y-undo-cursor-fix.ts
+++ b/packages/viola/src/libs/editor/y-undo-cursor-fix.ts
@@ -1,0 +1,98 @@
+import { Extension } from '@tiptap/core';
+import {
+  type ProsemirrorBinding,
+  ySyncPluginKey,
+  yUndoPluginKey,
+} from '@tiptap/y-tiptap';
+import type * as Y from 'yjs';
+
+// Restores the cursor at the right offset across Yjs undo/redo.
+//
+// Two issues in y-prosemirror's bundled cursor-restore make undo/redo land at
+// the wrong place:
+//
+// 1. The popped stack item's stored selection is loaded into
+//    `binding.beforeTransactionSelection` from a `stack-item-popped` listener,
+//    but that event fires *after* `cleanupTransactions` has already run the
+//    sync plugin's observer — so the observer dispatches with the previous
+//    operation's stored selection. We pre-load the correct value on
+//    `beforeObserverCalls` (which runs before observers, while
+//    `undoManager.currStackItem` is already set).
+//
+// 2. The inverse-direction stack item (the redo item created during an undo,
+//    or vice versa) is supposed to remember the *current* cursor so the next
+//    undo/redo can put the caret back there. y-prosemirror tries to capture
+//    that from `plugin.apply` running on the sync plugin's own dispatched
+//    transaction — but by then the Yjs items the cursor pointed at have
+//    already been deleted, so `absolutePositionToRelativePosition` falls back
+//    to `{ item: null, tname: 'default' }` (i.e. position 0). The fragment-
+//    level fallback can't be resolved back to a real offset, so the next
+//    redo/undo lands at the start. We instead snapshot the binding's *prior*
+//    `beforeTransactionSelection` (set by the last `_prosemirrorChanged`
+//    while the items still existed) inside `beforeObserverCalls` and
+//    overwrite the just-created inverse-stack item's meta after y-prosemirror
+//    has stored its (wrong) value.
+type RelativeSelection = ProsemirrorBinding['beforeTransactionSelection'];
+type BindingWithDoc = ProsemirrorBinding & { doc: Y.Doc };
+
+export const YUndoCursorFix = Extension.create({
+  name: 'yUndoCursorFix',
+
+  onCreate() {
+    const editor = this.editor;
+    const ystate = ySyncPluginKey.getState(editor.state) as
+      | { binding: BindingWithDoc | null }
+      | undefined;
+    const undoState = yUndoPluginKey.getState(editor.state) as
+      | { undoManager: Y.UndoManager }
+      | undefined;
+    const binding = ystate?.binding;
+    const undoManager = undoState?.undoManager;
+    if (!binding || !undoManager) {
+      return;
+    }
+    const doc = binding.doc;
+
+    let pendingInverseSelection: RelativeSelection | null = null;
+
+    const onBeforeObservers = (transaction: Y.Transaction) => {
+      if (transaction.origin !== undoManager) return;
+      const stackItem = undoManager.currStackItem;
+      if (!stackItem) return;
+
+      // Snapshot the pre-undo/redo cursor before we overwrite it. This is
+      // anchored to Yjs items that have been logically deleted but are
+      // still present (with their original IDs and a `.redone` link), so
+      // the relative position resolves back to the right offset on the
+      // inverse operation.
+      pendingInverseSelection = binding.beforeTransactionSelection;
+
+      const sel = stackItem.meta.get(binding) as RelativeSelection | undefined;
+      if (sel) {
+        binding.beforeTransactionSelection = sel;
+      }
+    };
+
+    const onStackItemAdded = ({
+      stackItem,
+    }: {
+      stackItem: { meta: Map<unknown, unknown> };
+    }) => {
+      if (pendingInverseSelection !== null) {
+        stackItem.meta.set(binding, pendingInverseSelection);
+        pendingInverseSelection = null;
+      }
+    };
+
+    doc.on('beforeObserverCalls', onBeforeObservers);
+    undoManager.on('stack-item-added', onStackItemAdded);
+    (this.storage as { cleanup?: () => void }).cleanup = () => {
+      doc.off('beforeObserverCalls', onBeforeObservers);
+      undoManager.off('stack-item-added', onStackItemAdded);
+    };
+  },
+
+  onDestroy() {
+    (this.storage as { cleanup?: () => void }).cleanup?.();
+  },
+});

--- a/packages/viola/src/libs/polyfills.ts
+++ b/packages/viola/src/libs/polyfills.ts
@@ -1,0 +1,17 @@
+// y-prosemirror's sync plugin calls `view._root.createRange()` from its
+// "is the local cursor in view?" check. When the ProseMirror editor lives
+// inside a Shadow DOM (as it does here via EditorStyleContainer), `_root` is a
+// ShadowRoot, which has no `createRange` method — `Document.createRange` is
+// the standard API. The thrown TypeError aborts the post-undo `tr.dispatch`,
+// leaving the editor visually out of sync with the underlying Yjs doc.
+// Delegating to the owning document is the same range factory either way.
+if (typeof ShadowRoot !== 'undefined') {
+  const proto = ShadowRoot.prototype as ShadowRoot & {
+    createRange?: () => Range;
+  };
+  if (typeof proto.createRange !== 'function') {
+    proto.createRange = function createRange(this: ShadowRoot): Range {
+      return (this.ownerDocument ?? document).createRange();
+    };
+  }
+}

--- a/packages/viola/src/main.tsx
+++ b/packages/viola/src/main.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 
 import { ThemeProvider } from '@v/ui/theme-provider';
+import './libs/polyfills';
 import { routeTree } from './routeTree.gen';
 import './main.css';
 

--- a/packages/viola/src/routeTree.gen.ts
+++ b/packages/viola/src/routeTree.gen.ts
@@ -9,7 +9,9 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as DebugIndexRouteImport } from './routes/debug/index'
 import { Route as mainLayoutRouteImport } from './routes/(main)/_layout'
+import { Route as DebugIndexeddbPersistenceIndexRouteImport } from './routes/debug/indexeddb-persistence/index'
 import { Route as DebugAstViewerIndexRouteImport } from './routes/debug/ast-viewer/index'
 import { Route as mainLayoutIndexRouteImport } from './routes/(main)/_layout/index'
 import { Route as mainLayoutNewProjectRouteImport } from './routes/(main)/_layout/new-project'
@@ -20,10 +22,21 @@ import { Route as mainLayoutProjectsProjectIdMediaRouteImport } from './routes/(
 import { Route as mainLayoutProjectsProjectIdBibliographyRouteImport } from './routes/(main)/_layout/projects/$projectId/bibliography'
 import { Route as mainLayoutProjectsProjectIdEditSplatRouteImport } from './routes/(main)/_layout/projects/$projectId/edit/$'
 
+const DebugIndexRoute = DebugIndexRouteImport.update({
+  id: '/debug/',
+  path: '/debug/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const mainLayoutRoute = mainLayoutRouteImport.update({
   id: '/(main)/_layout',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DebugIndexeddbPersistenceIndexRoute =
+  DebugIndexeddbPersistenceIndexRouteImport.update({
+    id: '/debug/indexeddb-persistence/',
+    path: '/debug/indexeddb-persistence/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const DebugAstViewerIndexRoute = DebugAstViewerIndexRouteImport.update({
   id: '/debug/ast-viewer/',
   path: '/debug/ast-viewer/',
@@ -77,9 +90,11 @@ const mainLayoutProjectsProjectIdEditSplatRoute =
   } as any)
 
 export interface FileRoutesByFullPath {
+  '/debug/': typeof DebugIndexRoute
   '/new-project': typeof mainLayoutNewProjectRoute
   '/': typeof mainLayoutIndexRoute
   '/debug/ast-viewer/': typeof DebugAstViewerIndexRoute
+  '/debug/indexeddb-persistence/': typeof DebugIndexeddbPersistenceIndexRoute
   '/projects/$projectId/bibliography': typeof mainLayoutProjectsProjectIdBibliographyRoute
   '/projects/$projectId/media': typeof mainLayoutProjectsProjectIdMediaRoute
   '/projects/$projectId/preview': typeof mainLayoutProjectsProjectIdPreviewRoute
@@ -88,9 +103,11 @@ export interface FileRoutesByFullPath {
   '/projects/$projectId/edit/$': typeof mainLayoutProjectsProjectIdEditSplatRoute
 }
 export interface FileRoutesByTo {
+  '/debug': typeof DebugIndexRoute
   '/new-project': typeof mainLayoutNewProjectRoute
   '/': typeof mainLayoutIndexRoute
   '/debug/ast-viewer': typeof DebugAstViewerIndexRoute
+  '/debug/indexeddb-persistence': typeof DebugIndexeddbPersistenceIndexRoute
   '/projects/$projectId/bibliography': typeof mainLayoutProjectsProjectIdBibliographyRoute
   '/projects/$projectId/media': typeof mainLayoutProjectsProjectIdMediaRoute
   '/projects/$projectId/preview': typeof mainLayoutProjectsProjectIdPreviewRoute
@@ -101,9 +118,11 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/(main)/_layout': typeof mainLayoutRouteWithChildren
+  '/debug/': typeof DebugIndexRoute
   '/(main)/_layout/new-project': typeof mainLayoutNewProjectRoute
   '/(main)/_layout/': typeof mainLayoutIndexRoute
   '/debug/ast-viewer/': typeof DebugAstViewerIndexRoute
+  '/debug/indexeddb-persistence/': typeof DebugIndexeddbPersistenceIndexRoute
   '/(main)/_layout/projects/$projectId/bibliography': typeof mainLayoutProjectsProjectIdBibliographyRoute
   '/(main)/_layout/projects/$projectId/media': typeof mainLayoutProjectsProjectIdMediaRoute
   '/(main)/_layout/projects/$projectId/preview': typeof mainLayoutProjectsProjectIdPreviewRoute
@@ -114,9 +133,11 @@ export interface FileRoutesById {
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
+    | '/debug/'
     | '/new-project'
     | '/'
     | '/debug/ast-viewer/'
+    | '/debug/indexeddb-persistence/'
     | '/projects/$projectId/bibliography'
     | '/projects/$projectId/media'
     | '/projects/$projectId/preview'
@@ -125,9 +146,11 @@ export interface FileRouteTypes {
     | '/projects/$projectId/edit/$'
   fileRoutesByTo: FileRoutesByTo
   to:
+    | '/debug'
     | '/new-project'
     | '/'
     | '/debug/ast-viewer'
+    | '/debug/indexeddb-persistence'
     | '/projects/$projectId/bibliography'
     | '/projects/$projectId/media'
     | '/projects/$projectId/preview'
@@ -137,9 +160,11 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/(main)/_layout'
+    | '/debug/'
     | '/(main)/_layout/new-project'
     | '/(main)/_layout/'
     | '/debug/ast-viewer/'
+    | '/debug/indexeddb-persistence/'
     | '/(main)/_layout/projects/$projectId/bibliography'
     | '/(main)/_layout/projects/$projectId/media'
     | '/(main)/_layout/projects/$projectId/preview'
@@ -150,16 +175,32 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   mainLayoutRoute: typeof mainLayoutRouteWithChildren
+  DebugIndexRoute: typeof DebugIndexRoute
   DebugAstViewerIndexRoute: typeof DebugAstViewerIndexRoute
+  DebugIndexeddbPersistenceIndexRoute: typeof DebugIndexeddbPersistenceIndexRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/debug/': {
+      id: '/debug/'
+      path: '/debug'
+      fullPath: '/debug/'
+      preLoaderRoute: typeof DebugIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/(main)/_layout': {
       id: '/(main)/_layout'
       path: ''
       fullPath: ''
       preLoaderRoute: typeof mainLayoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/debug/indexeddb-persistence/': {
+      id: '/debug/indexeddb-persistence/'
+      path: '/debug/indexeddb-persistence'
+      fullPath: '/debug/indexeddb-persistence/'
+      preLoaderRoute: typeof DebugIndexeddbPersistenceIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/debug/ast-viewer/': {
@@ -259,7 +300,9 @@ const mainLayoutRouteWithChildren = mainLayoutRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   mainLayoutRoute: mainLayoutRouteWithChildren,
+  DebugIndexRoute: DebugIndexRoute,
   DebugAstViewerIndexRoute: DebugAstViewerIndexRoute,
+  DebugIndexeddbPersistenceIndexRoute: DebugIndexeddbPersistenceIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/packages/viola/src/routes/debug/index.tsx
+++ b/packages/viola/src/routes/debug/index.tsx
@@ -1,0 +1,55 @@
+import { createFileRoute, Link } from '@tanstack/react-router';
+
+type DebugPage = {
+  to: string;
+  title: string;
+  description: string;
+};
+
+const debugPages: DebugPage[] = [
+  {
+    to: '/debug/ast-viewer',
+    title: 'AST Viewer',
+    description:
+      'Inspect TipTap ProseMirror and VFM AST/HTML side-by-side for a markdown + CSS pair.',
+  },
+  {
+    to: '/debug/indexeddb-persistence',
+    title: 'IndexedDB Persistence',
+    description:
+      'Minimal editor bound to a Yjs doc + y-indexeddb, with a live log of every persisted update entry.',
+  },
+];
+
+export const Route = createFileRoute('/debug/')({
+  component: DebugIndexView,
+});
+
+function DebugIndexView() {
+  return (
+    <div className="size-full overflow-auto p-8">
+      <div className="mx-auto max-w-2xl">
+        <h1 className="mb-2 text-2xl font-semibold">Debug pages</h1>
+        <p className="mb-6 text-muted-foreground text-sm">
+          Internal tools for inspecting editor and persistence behaviour.
+        </p>
+        <ul className="flex flex-col gap-3">
+          {debugPages.map((page) => (
+            <li key={page.to}>
+              <Link
+                to={page.to}
+                className="block rounded-md border border-neutral-300 px-4 py-3 transition-colors hover:bg-accent"
+              >
+                <div className="font-medium">{page.title}</div>
+                <div className="text-muted-foreground text-xs font-mono">
+                  {page.to}
+                </div>
+                <p className="mt-1 text-sm">{page.description}</p>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/packages/viola/src/routes/debug/indexeddb-persistence/index.tsx
+++ b/packages/viola/src/routes/debug/indexeddb-persistence/index.tsx
@@ -1,0 +1,409 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { Collaboration } from '@tiptap/extension-collaboration';
+import { Placeholder } from '@tiptap/extensions';
+import { EditorContext, useEditor } from '@tiptap/react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ref } from 'valtio';
+import { IndexeddbPersistence } from 'y-indexeddb';
+import * as Y from 'yjs';
+
+import { PubExtensions } from '@v/tiptap-extensions';
+import { InlineTrigger } from '@v/tiptap-extensions/inline-trigger';
+import { Button } from '@v/ui/button';
+import {
+  EditArea,
+  EditorStyleContainer,
+} from '../../../components/content-editor';
+import { ImageMenu } from '../../../components/content-editor/image-menu';
+import { InlineMenu } from '../../../components/content-editor/inline-menu';
+import { createObjectUrlImageSaver } from '../../../libs/editor/image-saver';
+import {
+  getAllTriggers,
+  inlineMenuState,
+} from '../../../libs/editor/inline-menu';
+import { insertImageFiles } from '../../../libs/editor/insert-image';
+import { YUndoCursorFix } from '../../../libs/editor/y-undo-cursor-fix';
+
+import '../../../libs/editor/inline-menu.media';
+
+const PERSISTENCE_NAME = 'viola:debug:indexeddb-persistence';
+
+export const Route = createFileRoute('/debug/indexeddb-persistence/')({
+  component: IndexeddbPersistenceDebugView,
+});
+
+type Handle = { doc: Y.Doc; persistence: IndexeddbPersistence };
+
+function IndexeddbPersistenceDebugView() {
+  const [handle, setHandle] = useState<Handle | null>(null);
+  // Resources must be created inside useEffect so that StrictMode's dev-only
+  // mount/unmount cycle creates a fresh Doc + IndexeddbPersistence on the real
+  // mount; a useRef body-init pattern would reuse references that the
+  // simulated unmount already destroyed (Y.Doc.destroy detaches the
+  // persistence's update listener, so subsequent edits silently never reach
+  // IndexedDB).
+  useEffect(() => {
+    const doc = new Y.Doc();
+    const persistence = new IndexeddbPersistence(PERSISTENCE_NAME, doc);
+    setHandle({ doc, persistence });
+    return () => {
+      persistence.destroy();
+      doc.destroy();
+      setHandle(null);
+    };
+  }, []);
+
+  return (
+    <div className="grid grid-cols-2 size-full divide-x divide-neutral-300">
+      <section className="flex flex-col min-h-0">
+        <header className="sticky top-0 z-10 bg-background px-6 py-2 border-b border-neutral-300 text-secondary-foreground font-semibold">
+          Editor
+        </header>
+        <div className="flex-1 min-h-0 overflow-auto">
+          {handle ? (
+            <EditorPane key={handle.doc.guid} doc={handle.doc} />
+          ) : (
+            <InitMessage />
+          )}
+        </div>
+      </section>
+      <section className="flex flex-col min-h-0">
+        <header className="sticky top-0 z-10 bg-background px-6 py-2 border-b border-neutral-300 text-secondary-foreground font-semibold">
+          IndexedDB Updates Log
+        </header>
+        <div className="flex-1 min-h-0 overflow-auto">
+          {handle ? (
+            <UpdatesPane
+              key={handle.doc.guid}
+              doc={handle.doc}
+              persistence={handle.persistence}
+            />
+          ) : (
+            <InitMessage />
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function InitMessage() {
+  return (
+    <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+      Initialising IndexedDB…
+    </div>
+  );
+}
+
+function EditorPane({ doc }: { doc: Y.Doc }) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const editor = useEditor({
+    extensions: [
+      PubExtensions.configure({
+        imageSaver: createObjectUrlImageSaver(),
+        onFileDrop: (editor, files, pos) => {
+          insertImageFiles({ editor, files, pos });
+        },
+        onFilePaste: (editor, files) => {
+          insertImageFiles({ editor, files });
+        },
+      }),
+      Placeholder.configure({
+        placeholder:
+          'Start typing — every keystroke is persisted to IndexedDB…',
+      }),
+      InlineTrigger.configure({
+        triggers: getAllTriggers(),
+        isMenuOpen: () => inlineMenuState.trigger !== null,
+        onDismiss: () => inlineMenuState.closeInlineMenu(),
+        onTrigger: (editor, trigger, from, coords) => {
+          inlineMenuState.trigger = trigger;
+          inlineMenuState.editor = ref(editor);
+          inlineMenuState.from = from;
+          inlineMenuState.coords = coords;
+        },
+      }),
+      Collaboration.configure({ document: doc }),
+      YUndoCursorFix,
+    ],
+  });
+
+  return (
+    <EditorContext.Provider value={{ editor }}>
+      <div ref={wrapperRef} className="relative h-full">
+        <EditorStyleContainer>
+          <EditArea />
+        </EditorStyleContainer>
+        <InlineMenu containerRef={wrapperRef} />
+        <ImageMenu containerRef={wrapperRef} />
+      </div>
+    </EditorContext.Provider>
+  );
+}
+
+type UpdateEntry = {
+  key: number;
+  byteLength: number;
+  structCount: number;
+  deleteSetClients: number;
+  preview: string;
+};
+
+function UpdatesPane({
+  doc,
+  persistence,
+}: {
+  doc: Y.Doc;
+  persistence: IndexeddbPersistence;
+}) {
+  const [entries, setEntries] = useState<UpdateEntry[]>([]);
+  const [synced, setSynced] = useState(persistence.synced);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const next = await readAllUpdates(PERSISTENCE_NAME);
+      setEntries(next);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const onSynced = () => {
+      setSynced(true);
+      void refresh();
+    };
+    persistence.on('synced', onSynced);
+    const onUpdate = () => {
+      // y-indexeddb writes asynchronously inside its own update handler;
+      // schedule a refresh on the next tick so the new row is visible.
+      setTimeout(() => {
+        void refresh();
+      }, 0);
+    };
+    doc.on('update', onUpdate);
+    return () => {
+      persistence.off('synced', onSynced);
+      doc.off('update', onUpdate);
+    };
+  }, [doc, persistence, refresh]);
+
+  const clearData = useCallback(async () => {
+    try {
+      await clearStore(PERSISTENCE_NAME);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, [refresh]);
+
+  const totalBytes = entries.reduce((sum, e) => sum + e.byteLength, 0);
+
+  return (
+    <div className="flex flex-col gap-3 p-4 text-sm">
+      <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 font-mono text-xs">
+        <dt className="text-muted-foreground">DB name</dt>
+        <dd className="break-all">{PERSISTENCE_NAME}</dd>
+        <dt className="text-muted-foreground">Synced</dt>
+        <dd>{synced ? 'yes' : 'no'}</dd>
+        <dt className="text-muted-foreground">Entries</dt>
+        <dd>{entries.length}</dd>
+        <dt className="text-muted-foreground">Total bytes</dt>
+        <dd>{totalBytes.toLocaleString()}</dd>
+      </dl>
+      <div className="flex gap-2">
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={refresh}
+          loading={loading}
+        >
+          Refresh
+        </Button>
+        <Button size="sm" variant="destructive" onClick={clearData}>
+          Clear updates store
+        </Button>
+      </div>
+      {error && (
+        <div className="rounded border border-destructive bg-destructive/10 px-3 py-2 text-destructive text-xs font-mono">
+          {error}
+        </div>
+      )}
+      <table className="w-full border-collapse text-xs font-mono">
+        <thead className="bg-accent text-left">
+          <tr>
+            <th className="px-2 py-1 border-b border-neutral-300">key</th>
+            <th className="px-2 py-1 border-b border-neutral-300">bytes</th>
+            <th className="px-2 py-1 border-b border-neutral-300">structs</th>
+            <th className="px-2 py-1 border-b border-neutral-300">
+              ds clients
+            </th>
+            <th className="px-2 py-1 border-b border-neutral-300">preview</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.length === 0 ? (
+            <tr>
+              <td
+                colSpan={5}
+                className="px-2 py-4 text-center text-muted-foreground"
+              >
+                No updates persisted yet.
+              </td>
+            </tr>
+          ) : (
+            entries.map((entry) => (
+              <tr key={entry.key} className="align-top">
+                <td className="px-2 py-1 border-b border-neutral-200">
+                  {entry.key}
+                </td>
+                <td className="px-2 py-1 border-b border-neutral-200">
+                  {entry.byteLength}
+                </td>
+                <td className="px-2 py-1 border-b border-neutral-200">
+                  {entry.structCount}
+                </td>
+                <td className="px-2 py-1 border-b border-neutral-200">
+                  {entry.deleteSetClients}
+                </td>
+                <td className="px-2 py-1 border-b border-neutral-200 break-all">
+                  {entry.preview}
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function openDb(name: string): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(name);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+    req.onblocked = () => reject(new Error(`open blocked for "${name}"`));
+  });
+}
+
+function getAllWithKeys(
+  store: IDBObjectStore,
+): Promise<Array<{ key: number; value: Uint8Array }>> {
+  return new Promise((resolve, reject) => {
+    const results: Array<{ key: number; value: Uint8Array }> = [];
+    const cursorReq = store.openCursor();
+    cursorReq.onerror = () => reject(cursorReq.error);
+    cursorReq.onsuccess = () => {
+      const cursor = cursorReq.result;
+      if (!cursor) {
+        resolve(results);
+        return;
+      }
+      results.push({
+        key: cursor.key as number,
+        value: cursor.value as Uint8Array,
+      });
+      cursor.continue();
+    };
+  });
+}
+
+async function readAllUpdates(name: string): Promise<UpdateEntry[]> {
+  const db = await openDb(name);
+  try {
+    if (!db.objectStoreNames.contains('updates')) {
+      return [];
+    }
+    const tx = db.transaction(['updates'], 'readonly');
+    const store = tx.objectStore('updates');
+    const rows = await getAllWithKeys(store);
+    return rows.map(({ key, value }) => describeUpdate(key, value));
+  } finally {
+    db.close();
+  }
+}
+
+async function clearStore(name: string): Promise<void> {
+  const db = await openDb(name);
+  try {
+    if (!db.objectStoreNames.contains('updates')) {
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(['updates'], 'readwrite');
+      tx.objectStore('updates').clear();
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+function describeUpdate(key: number, raw: Uint8Array): UpdateEntry {
+  try {
+    const decoded = Y.decodeUpdate(raw);
+    const dsClients = decoded.ds?.clients
+      ? (decoded.ds.clients as Map<number, unknown>).size
+      : 0;
+    return {
+      key,
+      byteLength: raw.byteLength,
+      structCount: decoded.structs.length,
+      deleteSetClients: dsClients,
+      preview: previewStructs(decoded.structs),
+    };
+  } catch (e) {
+    return {
+      key,
+      byteLength: raw.byteLength,
+      structCount: 0,
+      deleteSetClients: 0,
+      preview: `decode error: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+}
+
+function previewStructs(structs: ReadonlyArray<unknown>): string {
+  if (structs.length === 0) {
+    return '∅';
+  }
+  const summary = structs.slice(0, 4).map((s) => {
+    const ctor = (s as { constructor?: { name?: string } }).constructor?.name;
+    const content = (s as { content?: unknown }).content;
+    const contentCtor = (content as { constructor?: { name?: string } })
+      ?.constructor?.name;
+    const str = (content as { str?: string })?.str;
+    if (typeof str === 'string') {
+      return `${ctor ?? '?'}(${JSON.stringify(str.length > 24 ? `${str.slice(0, 24)}…` : str)})`;
+    }
+    if (contentCtor === 'ContentType') {
+      // ContentType wraps an AbstractType instance (YXmlElement, YXmlFragment,
+      // YText, …). Surface the wrapped type's class name, plus YXmlElement's
+      // nodeName when present (e.g. "paragraph"), so the row distinguishes
+      // structural inserts from each other.
+      const wrapped = (content as { type?: unknown }).type;
+      const wrappedCtor = (wrapped as { constructor?: { name?: string } })
+        ?.constructor?.name;
+      const nodeName = (wrapped as { nodeName?: string })?.nodeName;
+      const inner = nodeName
+        ? `${wrappedCtor ?? '?'}:${nodeName}`
+        : (wrappedCtor ?? '?');
+      return `${ctor ?? '?'}<${contentCtor}<${inner}>>`;
+    }
+    return contentCtor ? `${ctor ?? '?'}<${contentCtor}>` : (ctor ?? '?');
+  });
+  return structs.length > summary.length
+    ? `${summary.join(', ')}, … +${structs.length - summary.length}`
+    : summary.join(', ');
+}

--- a/packages/viola/src/stores/actions/content-file.ts
+++ b/packages/viola/src/stores/actions/content-file.ts
@@ -5,7 +5,7 @@ import { ref } from 'valtio';
 
 import { setupEditor } from '../../libs/editor';
 import { generateId, generateRandomName } from '../../libs/generate-id';
-import { $content, $sandbox, $ui } from '../accessors';
+import { $content, $project, $sandbox, $ui } from '../accessors';
 import type { ContentId } from '../proxies/content';
 import { SandboxFile } from '../proxies/sandbox';
 
@@ -18,6 +18,7 @@ export async function createContentFile({
 }): Promise<ContentId> {
   const $$content = $content.valueOrThrow();
   const $$sandbox = $sandbox.valueOrThrow();
+  const projectId = $project.valueOrThrow().projectId;
   const prevFile = insertAfter && $$content.files.get(insertAfter);
   const entryContext = $$sandbox.vivliostyleConfig.entryContext || '';
   const prevFileDir =
@@ -44,7 +45,9 @@ export async function createContentFile({
     format,
     filename,
     summary: '',
-    editor: ref(await setupEditor({ contentId, filename, entryContext })),
+    editor: ref(
+      await setupEditor({ projectId, contentId, filename, entryContext }),
+    ),
   });
   $$content.readingOrder.splice(index, 0, contentId);
   return contentId;

--- a/packages/viola/src/stores/proxies/project.ts
+++ b/packages/viola/src/stores/proxies/project.ts
@@ -145,6 +145,7 @@ export class Project {
       }
       const contentId = generateId<ContentId>();
       const editor = await setupEditor({
+        projectId: this.projectId,
         contentId,
         filename,
         entryContext,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -789,9 +789,6 @@ importers:
       html-react-parser:
         specifier: 'catalog:'
         version: 6.1.0(@types/react@19.2.14)(react@19.2.6)
-      idb:
-        specifier: 8.0.3
-        version: 8.0.3
       nanoid:
         specifier: 'catalog:'
         version: 5.1.11
@@ -4971,9 +4968,6 @@ packages:
 
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
-
-  idb@8.0.3:
-    resolution: {integrity: sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -12167,8 +12161,6 @@ snapshots:
       safer-buffer: 2.1.2
 
   idb@7.1.1: {}
-
-  idb@8.0.3: {}
 
   ieee754@1.2.1: {}
 


### PR DESCRIPTION
## Summary

Persist each content file's TipTap editor across reloads by binding it to a Yjs document and storing that document in IndexedDB via `y-indexeddb`. Until now the editor was reconstructed from the on-disk markdown on every load, so in-editor history (and any state not representable in markdown) was lost on refresh.

## Changes

- Bind each editor to a `Y.Doc` through the `@tiptap/extension-collaboration` extension and attach `IndexeddbPersistence` from `y-indexeddb`.
- Key the IndexedDB store by a stable `viola:editor:<projectId>:<filename>` name. `contentId` is regenerated on every load, so it cannot be used as the key; `filename` is stable and `projectId` disambiguates identical paths across projects.
- On open, load persisted state first (`await persistence.whenSynced`); seed from the on-disk markdown only when the document has no editor history yet (first open), using `setContent(md, { contentType: 'markdown', emitUpdate: false })` so seeding neither rewrites the source file nor requires the project to be current.
- Keep serializing edits back to markdown in OPFS for the Vivliostyle CLI build.
- Destroy the persistence and `Y.Doc` when the editor is destroyed.
- `saveContent` now bails out when no project/sandbox is current, because Collaboration hydration can emit updates before the owning project becomes active.
- Remove the disabled hand-rolled IndexedDB persistence and the now-unused `idb` dependency.

Editor data flow: `IndexedDB (Y.Doc)` is the editor's persistent state; OPFS markdown remains the build input and the first-open seed source.

## Call sites

`setupEditor` now takes `projectId`, passed from `Project.restoreProjectFromFileSystem` (`this.projectId`) and `createContentFile` (`$project.valueOrThrow().projectId`).

## Verification

- [ ] `pnpm typecheck` — green
- [ ] `pnpm check` — Biome lint/format green
- [ ] `pnpm test` — cli-bundle 7 + storage-providers 31 = 38 tests, all green
- [ ] `pnpm --filter @v/viola build` — succeeds
- [ ] Manual: edit a file, reload, and confirm the content is restored from IndexedDB
- [ ] Manual: create a fresh project and confirm the first open seeds from the template markdown
- [ ] Manual: confirm edits still propagate to the preview/build (markdown written to OPFS)

> [!NOTE]
> Browser behavior was not verified in CI: the dev server requires `secrets/` (HTTPS cert + `VITE_APP_HOSTNAME`), which is unavailable in the sandbox. The manual checks above should be run locally or against the PR preview.

## Known limitations

- Editing the raw markdown outside the rich editor (e.g. a future raw-source editor) would not feed back into the Y.Doc; on reload the persisted Y.Doc wins. The CodeMirror editor today is only used for CSS/theme, so content files are unaffected.
- Deleting or renaming a file does not yet purge its IndexedDB store. A renamed file re-seeds from its (preserved) markdown, so content survives but editor history does not.

https://claude.ai/code/session_01CEpiAaGXFGdFWUzHWFQngf

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEpiAaGXFGdFWUzHWFQngf)_