### PR TITLE
fix: Unblock sandbox CLI bootstrap and preview rendering

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -34,6 +34,7 @@
     "ignoreUnknown": false,
     "includes": [
       "**",
+      "!**/.wt/**",
       "!**/packages/cli-bundle/src/stubs/rollup/**/*",
       "!**/vivliostyle-pub/**/*",
       "!**/routeTree.gen.ts",

--- a/packages/cli-bundle/rolldown.config.ts
+++ b/packages/cli-bundle/rolldown.config.ts
@@ -356,6 +356,28 @@ const patchRolldownBindingPlugin: Plugin = {
   },
 };
 
+// `parse-entities@2`'s package.json ships a `browser` field that swaps
+// `./decode-entity.js` (a static lookup table) for `./decode-entity.browser.js`,
+// which decodes via `document.createElement('i').innerHTML = '&...;'`. With
+// `platform: 'browser'` rolldown picks the browser variant, but the cli-bundle
+// runs in a Web Worker where `document` is undefined, so the markdown pipeline
+// throws `ReferenceError: document is not defined` as soon as it parses any
+// entity-bearing text. Replace the browser-variant module's body with the Node
+// version (pure JS lookup table), which works in workers.
+const undoParseEntitiesBrowserPlugin: Plugin = {
+  name: 'undo-parse-entities-browser',
+  load: {
+    filter: { id: /[\\/]parse-entities[\\/]decode-entity\.browser\.js$/ },
+    handler(id) {
+      const nodeVariant = id.replace(
+        /decode-entity\.browser\.js$/,
+        'decode-entity.js',
+      );
+      return fs.readFileSync(nodeVariant, 'utf8');
+    },
+  },
+};
+
 const copyWasmFilePlugin: Plugin = {
   name: 'copy-wasm-file',
   generateBundle() {
@@ -458,6 +480,7 @@ const workerConfig = defineConfig({
     patchEmnapiEnvDetectionPlugin,
     redirectRolldownToBrowserPlugin,
     resolveImportMetaPlugin,
+    undoParseEntitiesBrowserPlugin,
     copyWasmFilePlugin,
     visualizer() as Plugin,
   ],

--- a/packages/viola/src/stores/proxies/cli.ts
+++ b/packages/viola/src/stores/proxies/cli.ts
@@ -1,7 +1,6 @@
 import * as Comlink from 'comlink';
 import { proxy, ref } from 'valtio';
 
-import { awaiter } from '../../libs/awaiter';
 import type { Sandbox } from './sandbox';
 
 export type RemoteCli = Comlink.Remote<typeof import('@v/cli-bundle')>;
@@ -16,22 +15,20 @@ export class Cli {
   viewerIframeElement: HTMLIFrameElement | undefined;
 
   protected sandbox: Sandbox;
-  protected remoteAbortController: AbortController | undefined;
-  protected lazyRemotePromise: Promise<RemoteCli> | undefined;
+  protected remoteDeferred: PromiseWithResolvers<RemoteCli> | undefined;
   protected lazyViewerUrlPromise: Promise<string> | undefined;
 
   protected constructor(sandbox: Sandbox) {
     this.sandbox = ref(sandbox);
   }
 
-  createRemotePromise() {
-    this.remoteAbortController ??= ref(new AbortController());
-    this.lazyRemotePromise ??= awaiter({
-      getter: () => Cli.remoteMap.get(this.sandbox.iframeOrigin),
-      name: 'createRemoteResolver',
-      abortSignal: this.remoteAbortController.signal,
-    });
-    return this.lazyRemotePromise;
+  createRemotePromise(): Promise<RemoteCli> {
+    const existing = Cli.remoteMap.get(this.sandbox.iframeOrigin);
+    if (existing) {
+      return Promise.resolve(existing);
+    }
+    this.remoteDeferred ??= ref(Promise.withResolvers<RemoteCli>());
+    return this.remoteDeferred.promise;
   }
 
   createViewerUrlPromise() {
@@ -47,7 +44,8 @@ export class Cli {
     return {
       resolve: (value: RemoteCli) => {
         Cli.remoteMap.set(this.sandbox.iframeOrigin, value);
-        this.remoteAbortController = undefined;
+        this.remoteDeferred?.resolve(value);
+        this.remoteDeferred = undefined;
       },
       reset: () => {
         this.disposeRemote();
@@ -61,8 +59,8 @@ export class Cli {
       remote[Comlink.releaseProxy]();
       Cli.remoteMap.delete(this.sandbox.iframeOrigin);
     }
-    this.remoteAbortController?.abort();
-    this.lazyRemotePromise = undefined;
+    this.remoteDeferred?.reject(new Error('CLI remote disposed'));
+    this.remoteDeferred = undefined;
     this.lazyViewerUrlPromise = undefined;
   }
 

--- a/packages/viola/src/stores/proxies/project.ts
+++ b/packages/viola/src/stores/proxies/project.ts
@@ -7,7 +7,7 @@ import { deepClone } from 'valtio/utils';
 import { setupEditor } from '../../libs/editor';
 import { generateId } from '../../libs/generate-id';
 import { Content, type ContentId } from './content';
-import { Sandbox } from './sandbox';
+import { Sandbox, SandboxFile } from './sandbox';
 import { Theme } from './theme';
 
 function detectBrowserLanguage(): string {
@@ -167,7 +167,13 @@ export class Project {
       });
     }
     this.content.readingOrder = readingOrder;
-    this.theme.customCss = await sandbox.files['style.css'].text();
+    const styleCss = sandbox.files['style.css'];
+    if (styleCss) {
+      this.theme.customCss = await styleCss.text();
+    } else {
+      this.theme.customCss = '';
+      sandbox.files['style.css'] = ref(new SandboxFile('text/css', ''));
+    }
     if (
       Array.isArray(sandbox.vivliostyleConfig.theme) &&
       sandbox.vivliostyleConfig.theme[0] in Theme.officialThemes


### PR DESCRIPTION
## Summary

Fixes a stack of issues that prevented the `/preview` route from rendering and made the sandbox CLI bootstrap fragile on fresh subdomains (introduced/worsened by the multi-project + per-project-subdomain work in #42).

## Changes

- **`cli.ts`** — Replace the 10s polling `awaiter` for the remote CLI with a `Promise.withResolvers` deferred. New sandbox subdomains have to go through SW install + reload + ~14 MB cli-bundle download before they can post `bind`, which routinely blew past the polling timeout and surfaced as `Awaiter timeout: createRemoteResolver`.
- **`project.ts`** — When loading a project whose `vivliostyle.config.json` references `./style.css` but the file is missing on disk, materialize an empty `style.css` via `sandbox.files`. Restores existing projects that ended up with this inconsistency and stops CLI's `parseTheme` from throwing `Could not determine the package name: ./style.css`.
- **`rolldown.config.ts`** — `parse-entities@2`'s `browser` field swaps the entity decoder for one that calls `document.createElement('i').innerHTML`, which throws `ReferenceError: document is not defined` in the Web Worker as soon as any markdown entity is parsed. New `undoParseEntitiesBrowserPlugin` swaps the browser-variant module body for the Node lookup-table version at bundle time.
- **`biome.json`** — Ignore `.wt/**` so nested worktree biome configs no longer break the pre-commit hook.

## Test plan

- [x] \`pnpm typecheck\` — green (8/8)
- [x] \`pnpm --filter @v/cli-bundle test\` — green (7/7)
- [x] Manual: open existing project at \`/projects/alpha-v1\` → editor renders
- [x] Manual: \`/projects/alpha-v1/preview\` → Vivliostyle viewer renders cover page (1/115)

🤖 Generated with [Claude Code](https://claude.com/claude-code)