### PR TITLE
fix(viola): Replace `__IFRAME_HTML__` placeholder in minified `sw.js`

### DIFF
--- a/packages/viola/vite.config.ts
+++ b/packages/viola/vite.config.ts
@@ -177,7 +177,7 @@ const serviceWorker = () => [
           swFilename,
           fs
             .readFileSync(swFilename, 'utf8')
-            .replace(/"__IFRAME_HTML__"/g, JSON.stringify(html)),
+            .replace(/(["'`])__IFRAME_HTML__\1/g, () => JSON.stringify(html)),
           'utf8',
         );
       },


### PR DESCRIPTION
## Summary

Production `sw.js` shipped with the literal `__IFRAME_HTML__` placeholder unreplaced, so every sandbox iframe loaded `<body>__IFRAME_HTML__</body>` instead of the real iframe HTML. Consequently `iframe.ts` never ran, the CLI worker never bound, and `cli.createRemotePromise()` hung forever — manifesting as an infinite loading state on `/new-project` template selection and elsewhere.

The post-build `closeBundle` regex matched only double-quoted `"__IFRAME_HTML__"`, but the minifier rewrote it as a template literal `` `__IFRAME_HTML__` ``, so the replacement silently no-op'd. PR #46's `Promise.withResolvers` rewrite removed the 10s timeout that previously surfaced this as `Awaiter timeout: createRemoteResolver`, which is why the symptom flipped from "timeout error" to "infinite loading."

## Changes

- `vite.config.ts`: Accept any of `"`, `'`, or `` ` `` as the surrounding quote when replacing the placeholder in the built `sw.js`.

## Verification

- `pnpm --filter @v/viola exec vite build` rewrites `dist/sw.js` so `__IFRAME_HTML__` is gone and the actual iframe HTML is embedded as a JSON string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)