### PR TITLE
feat(viola): Add provider sign-in to the extension host API

### DIFF
--- a/packages/extension-kit/src/index.ts
+++ b/packages/extension-kit/src/index.ts
@@ -69,7 +69,7 @@ export type ExtensionSessionListener = (
  * granted permissions unlock:
  *   - `session:read`  → `getSessionSnapshot`, `subscribeSession`
  *   - `session:write` → `login`, `register`, `logout`, `applyBearerSession`,
- *                       `clearBearerSession`
+ *                       `clearBearerSession`, `startProviderSignIn`
  *   - `viewer:read`   → `getViewerUrl`
  */
 export type ExtensionPermission =
@@ -97,6 +97,7 @@ export interface ExtensionHostApi {
   logout(): Promise<void>;
   applyBearerSession(token: string): Promise<void>;
   clearBearerSession(): Promise<void>;
+  startProviderSignIn(provider: string): Promise<void>;
   getLocale(): string;
   getViewerUrl(): Promise<string>;
 }

--- a/packages/viola/src/components/panes/pane.extension.tsx
+++ b/packages/viola/src/components/panes/pane.extension.tsx
@@ -23,6 +23,7 @@ import {
   logout,
   register,
   SessionError,
+  startProviderSignIn,
 } from '../../stores/actions/session';
 import {
   type ExtensionId,
@@ -118,6 +119,12 @@ const hostApiRegistry: HostApiRegistry = {
   clearBearerSession: {
     permission: 'session:write',
     impl: () => runAuth(() => clearBearerSession()),
+  },
+  startProviderSignIn: {
+    permission: 'session:write',
+    impl: async (provider) => {
+      startProviderSignIn(provider);
+    },
   },
   getViewerUrl: {
     permission: 'viewer:read',

--- a/packages/viola/src/stores/actions/session.ts
+++ b/packages/viola/src/stores/actions/session.ts
@@ -189,12 +189,12 @@ async function completePendingProviderSignIn(): Promise<boolean> {
   if (!nonce) {
     return false;
   }
-  url.searchParams.delete(PROVIDER_NONCE_PARAM);
-  history.replaceState(null, '', url.href);
   const token = await claimProviderToken(providerApiBase(), nonce);
   if (!token) {
     return false;
   }
+  url.searchParams.delete(PROVIDER_NONCE_PARAM);
+  history.replaceState(history.state, '', url.href);
   await applyBearerSession(token);
   return true;
 }

--- a/packages/viola/src/stores/actions/session.ts
+++ b/packages/viola/src/stores/actions/session.ts
@@ -50,6 +50,9 @@ export function restoreSession(): Promise<void> {
       discoverProjects().catch(() => {});
       return;
     }
+    if (await completePendingProviderSignIn()) {
+      return;
+    }
     try {
       const user = await $session.auth.getUser();
       if (user) {
@@ -134,4 +137,64 @@ export async function applyBearerSession(sessionToken: string): Promise<void> {
 
 export async function clearBearerSession(): Promise<void> {
   await logout();
+}
+
+const PROVIDER_NONCE_PARAM = 'vp_provider_signin';
+
+function providerApiBase(): string {
+  return new URL($session.baseUrl || '/', location.origin).href.replace(
+    /\/+$/,
+    '',
+  );
+}
+
+export function startProviderSignIn(provider: string): void {
+  const nonce = (crypto.randomUUID() + crypto.randomUUID()).replaceAll('-', '');
+  const returnUrl = new URL(location.href);
+  returnUrl.searchParams.set(PROVIDER_NONCE_PARAM, nonce);
+  const start = new URL(`${providerApiBase()}/auth/provider/start`);
+  start.searchParams.set('provider', provider);
+  start.searchParams.set('return', returnUrl.href);
+  location.assign(start.href);
+}
+
+async function claimProviderToken(
+  base: string,
+  nonce: string,
+): Promise<string | null> {
+  const url = `${base}/auth/provider/claim?nonce=${encodeURIComponent(nonce)}`;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (attempt > 0) {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    }
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        const data = (await res.json()) as { status?: string; token?: string };
+        if (data.status === 'ok' && data.token) {
+          return data.token;
+        }
+      }
+    } catch {}
+  }
+  return null;
+}
+
+async function completePendingProviderSignIn(): Promise<boolean> {
+  if (typeof location === 'undefined') {
+    return false;
+  }
+  const url = new URL(location.href);
+  const nonce = url.searchParams.get(PROVIDER_NONCE_PARAM);
+  if (!nonce) {
+    return false;
+  }
+  url.searchParams.delete(PROVIDER_NONCE_PARAM);
+  history.replaceState(null, '', url.href);
+  const token = await claimProviderToken(providerApiBase(), nonce);
+  if (!token) {
+    return false;
+  }
+  await applyBearerSession(token);
+  return true;
 }


### PR DESCRIPTION
Adds a new `startProviderSignIn(provider)` method to the extension host API, letting extensions initiate sign-in through an external authentication provider (gated by the existing `session:write` permission).

- **`@v/extension-kit`**: declares `startProviderSignIn(provider: string): Promise<void>` on `ExtensionHostApi` and documents it under the `session:write` permission.
- **`@v/viola`**: registers the method in the extension host API registry and implements the flow:
  - `startProviderSignIn` generates a random nonce, appends it to the current URL as a `return` target, and redirects the browser to `<baseUrl>/auth/provider/start?provider=…&return=…`.
  - On return, session restoration detects the nonce in the URL, strips it via `history.replaceState`, and claims the resulting bearer token from `<baseUrl>/auth/provider/claim?nonce=…` (retried a few times). The token is then applied as the active session.

This enables redirect-based provider (OAuth-style) sign-in from within an extension, complementing the existing email/password and bearer-token session methods.