### PR TITLE
refactor(api-server-reference): rename createApiDevServer to createApiMiddleware

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -35,7 +35,6 @@
     "includes": [
       "**",
       "!**/packages/cli-bundle/src/stubs/rollup/**/*",
-      "!**/vivliostyle-pub/**/*",
       "!**/routeTree.gen.ts",
       "!**/packages/api-client/src/schema.d.ts",
       "!**/packages/api-spec/src/openapi.yaml",

--- a/packages/api-server-reference/src/middleware.ts
+++ b/packages/api-server-reference/src/middleware.ts
@@ -21,7 +21,7 @@ import { registerSyncWebSocket } from './sync/websocket';
  */
 type AnyHttpServer = HttpServer | Http2Server | Http2SecureServer;
 
-export interface CreateApiDevServerOptions extends CreateAppOptions {
+export interface CreateApiMiddlewareOptions extends CreateAppOptions {
   /**
    * Path prefix the API is mounted under on the host dev server.
    *
@@ -67,8 +67,8 @@ export interface ApiDevServer {
  * be wired into any Node http server (e.g. Vite's `server.httpServer`) so the
  * app and API share a single origin during local development.
  */
-export function createApiDevServer(
-  options: CreateApiDevServerOptions = {},
+export function createApiMiddleware(
+  options: CreateApiMiddlewareOptions = {},
 ): ApiDevServer {
   const {
     basePath: rawBasePath = '/api',

--- a/packages/api-server-reference/src/sync/websocket.test.ts
+++ b/packages/api-server-reference/src/sync/websocket.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import * as syncProtocol from 'y-protocols/sync';
 import * as Y from 'yjs';
 
-import { createApiDevServer } from '../dev-server';
+import { createApiMiddleware } from '../middleware';
 
 const MESSAGE_SYNC = 0;
 
@@ -78,7 +78,7 @@ describe('sync WebSocket', () => {
   let wsBase: string;
 
   beforeEach(async () => {
-    const api = createApiDevServer();
+    const api = createApiMiddleware();
     const http = createServer((req, res) => {
       api.middleware(req, res, () => {
         res.statusCode = 404;

--- a/packages/viola/vite.config.ts
+++ b/packages/viola/vite.config.ts
@@ -7,10 +7,17 @@ import { paraglideVitePlugin } from '@inlang/paraglide-js';
 import tailwindcss from '@tailwindcss/vite';
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite';
 import react from '@vitejs/plugin-react-swc';
+import { invariant } from 'outvariant';
 import { visualizer } from 'rollup-plugin-visualizer';
 import sirv from 'sirv';
 import * as tar from 'tar';
-import { defineConfig, loadEnv, type Plugin, type PluginOption } from 'vite';
+import {
+  defineConfig,
+  loadEnv,
+  type Plugin,
+  type PluginOption,
+  type ResolvedConfig,
+} from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
 
 // @ts-expect-error
@@ -39,10 +46,14 @@ const createTemplateTgz = (templateName: string): Promise<Buffer> => {
   });
 };
 
-const serveTemplates = () =>
-  ({
+const serveTemplates = () => {
+  let config: ResolvedConfig | undefined;
+  return {
     name: 'serve-templates',
     enforce: 'pre',
+    configResolved(resolvedConfig) {
+      config = resolvedConfig;
+    },
     configureServer(server) {
       server.middlewares.use('/_templates', async (req, res, next) => {
         const match = req.url?.match(/^\/([^/]+)\.tar\.gz$/);
@@ -62,21 +73,27 @@ const serveTemplates = () =>
       });
     },
     async closeBundle() {
+      invariant(config, 'Vite config not resolved');
       const entries = fs.readdirSync(templatesDir, { withFileTypes: true });
       for (const entry of entries) {
         if (!entry.isDirectory()) continue;
         const buf = await createTemplateTgz(entry.name);
-        const destDir = path.join(dirname, 'dist/_templates');
+        const destDir = path.join(config.build.outDir, '_templates');
         fs.mkdirSync(destDir, { recursive: true });
         fs.writeFileSync(path.join(destDir, `${entry.name}.tar.gz`), buf);
       }
     },
-  }) satisfies Plugin;
+  } satisfies Plugin;
+};
 
-const serveCli = () =>
-  ({
+const serveCli = () => {
+  let config: ResolvedConfig | undefined;
+  return {
     name: 'serve-cli',
     enforce: 'pre',
+    configResolved(resolvedConfig) {
+      config = resolvedConfig;
+    },
     configureServer(server) {
       const dir = path.resolve(
         require.resolve('@v/cli-bundle/package.json'),
@@ -117,15 +134,17 @@ const serveCli = () =>
       }
     },
     closeBundle() {
+      invariant(config, 'Vite config not resolved');
       const src = path.resolve(
         require.resolve('@v/cli-bundle/package.json'),
         '../dist',
       );
-      const dest = path.join(dirname, 'dist/_cli');
+      const dest = path.join(config.build.outDir, '_cli');
       fs.mkdirSync(dest, { recursive: true });
       fs.cpSync(src, dest, { recursive: true });
     },
-  }) satisfies Plugin;
+  } satisfies Plugin;
+};
 
 // Extensions are the workspace packages named `@v/viola-extension-<id>`,
 // enumerated through pnpm itself so they are found wherever the workspace
@@ -253,9 +272,9 @@ const serveApi = ({
       // through vite's plugin pipeline and resolves them correctly.
       const loadApi = async () => {
         const mod = (await server.ssrLoadModule(
-          '@v/api-server-reference/dev-server',
-        )) as typeof import('@v/api-server-reference/dev-server');
-        return mod.createApiDevServer({ sqlitePath, projectFilePath });
+          '@v/api-server-reference/middleware',
+        )) as typeof import('@v/api-server-reference/middleware');
+        return mod.createApiMiddleware({ sqlitePath, projectFilePath });
       };
 
       let api = await loadApi();
@@ -336,75 +355,82 @@ const serveApi = ({
   };
 };
 
-const serviceWorker = () => [
-  VitePWA({
-    strategies: 'injectManifest',
-    srcDir: 'src/client',
-    filename: 'sw.ts',
-    injectRegister: null,
-    manifest: false,
-    injectManifest: {
-      injectionPoint: undefined,
-    },
-    devOptions: {
-      enabled: true,
-      type: 'module',
-    },
-  }),
-  {
-    name: 'iframe-html-dev',
-    enforce: 'post',
-    apply: 'serve',
-    config(config) {
-      // The iframe HTML is served raw by the service worker, bypassing Vite's
-      // index-HTML transform, so the React Refresh preamble that
-      // @vitejs/plugin-react-swc normally injects is missing.
-      const preamble = `<script type="module">
+const serviceWorker = () => {
+  let config: ResolvedConfig | undefined;
+  return [
+    VitePWA({
+      strategies: 'injectManifest',
+      srcDir: 'src/client',
+      filename: 'sw.ts',
+      injectRegister: null,
+      manifest: false,
+      injectManifest: {
+        injectionPoint: undefined,
+      },
+      devOptions: {
+        enabled: true,
+        type: 'module',
+      },
+    }),
+    {
+      name: 'iframe-html-dev',
+      enforce: 'post',
+      apply: 'serve',
+      config(config) {
+        // The iframe HTML is served raw by the service worker, bypassing Vite's
+        // index-HTML transform, so the React Refresh preamble that
+        // @vitejs/plugin-react-swc normally injects is missing.
+        const preamble = `<script type="module">
         import { injectIntoGlobalHook } from "/@react-refresh";
         injectIntoGlobalHook(window);
         window.$RefreshReg$ = () => {};
         window.$RefreshSig$ = () => (type) => type;
       </script>`;
-      const html = fs
-        .readFileSync(path.join(dirname, 'iframe.html'), 'utf8')
-        .replace('<script', `${preamble}\n<script`);
-      config.define = {
-        ...config.define,
-        'import.meta.env.VITE_IFRAME_HTML': JSON.stringify(html),
-      };
-      return config;
-    },
-  } satisfies Plugin,
-  {
-    name: 'iframe-html-build',
-    enforce: 'post',
-    apply: 'build',
-    config(config) {
-      config.define = {
-        ...config.define,
-        'import.meta.env.VITE_IFRAME_HTML': JSON.stringify('__IFRAME_HTML__'),
-      };
-      return config;
-    },
-    closeBundle: {
-      sequential: true,
-      handler() {
-        const html = fs.readFileSync(
-          path.join(dirname, 'dist/iframe.html'),
-          'utf8',
-        );
-        const swFilename = path.join(dirname, 'dist/sw.js');
-        fs.writeFileSync(
-          swFilename,
-          fs
-            .readFileSync(swFilename, 'utf8')
-            .replace(/(["'`])__IFRAME_HTML__\1/g, () => JSON.stringify(html)),
-          'utf8',
-        );
+        const html = fs
+          .readFileSync(path.join(dirname, 'iframe.html'), 'utf8')
+          .replace('<script', `${preamble}\n<script`);
+        config.define = {
+          ...config.define,
+          'import.meta.env.VITE_IFRAME_HTML': JSON.stringify(html),
+        };
+        return config;
       },
-    },
-  } satisfies Plugin,
-];
+    } satisfies Plugin,
+    {
+      name: 'iframe-html-build',
+      enforce: 'post',
+      apply: 'build',
+      config(config) {
+        config.define = {
+          ...config.define,
+          'import.meta.env.VITE_IFRAME_HTML': JSON.stringify('__IFRAME_HTML__'),
+        };
+        return config;
+      },
+      configResolved(resolvedConfig) {
+        config = resolvedConfig;
+      },
+      closeBundle: {
+        sequential: true,
+        handler() {
+          invariant(config, 'Vite config not resolved');
+          const html = fs.readFileSync(
+            path.join(config.build.outDir, 'iframe.html'),
+            'utf8',
+          );
+          const swFilename = path.join(config.build.outDir, 'sw.js');
+          fs.writeFileSync(
+            swFilename,
+            fs
+              .readFileSync(swFilename, 'utf8')
+              .replace(/(["'`])__IFRAME_HTML__\1/g, () => JSON.stringify(html)),
+            'utf8',
+          );
+        },
+      },
+    } satisfies Plugin,
+  ];
+};
 
 // https://vite.dev/config/
 export default defineConfig(({ mode, command }) => {
@@ -417,6 +443,8 @@ export default defineConfig(({ mode, command }) => {
   const apiBaseUrl =
     env.VITE_API_BASE_URL || (command === 'serve' ? '/api' : '');
   const cloudEnabled = env.VITE_DISABLE_CLOUD !== 'true' && Boolean(apiBaseUrl);
+  const apiServerEnabled =
+    env.VITE_DISABLE_REFERENCE_API_SERVER !== 'true' && cloudEnabled;
 
   return {
     define: {
@@ -450,7 +478,7 @@ export default defineConfig(({ mode, command }) => {
       serveTemplates(),
       serveCli(),
       installedExtensions(),
-      ...(cloudEnabled
+      ...(apiServerEnabled
         ? [
             serveApi({
               sqlitePath: env.API_SQLITE_PATH


### PR DESCRIPTION
Renames the reference API server's `dev-server` module to `middleware` and its exports `createApiDevServer`/`CreateApiDevServerOptions` to `createApiMiddleware`/`CreateApiMiddlewareOptions`, reflecting that it produces a mountable middleware rather than a dev-only server. The sync WebSocket test and the `viola` Vite config are updated to import from the new path and name.

Alongside the rename, this tidies up `viola`'s `vite.config.ts`:

- The `serve-templates`, `serve-cli`, and `iframe-html-build` plugins now derive their output directory from the resolved Vite config (`config.build.outDir`, captured in `configResolved`) instead of hardcoding `dist/...`, so they honor a custom build output directory. An `invariant` guard asserts the config has been resolved before use.
- Adds a `VITE_DISABLE_REFERENCE_API_SERVER` environment flag that gates mounting the reference API server plugin during local development, in addition to the existing cloud check.

Also drops a stale `!**/vivliostyle-pub/**/*` entry from `biome.json`'s ignore list.