### PR TITLE
Add sandbox subdomain identifier to isolate preview origins

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -28,6 +28,7 @@ jobs:
       preview: ${{ steps.build-env.outputs.preview }}
       preview-alias: ${{ steps.build-env.outputs.preview-alias }}
       hostname: ${{ steps.build-env.outputs.hostname }}
+      sandbox-identifier: ${{ steps.build-env.outputs.sandbox-identifier }}
     steps:
       - uses: vivliostyle/vivliostyle.pub/.github/actions/setup@main
       - name: Determine build environment
@@ -36,15 +37,18 @@ jobs:
           if [[ "${{ github.ref_name }}" == "${{ github.event.repository.default_branch }}" ]]; then
             echo "preview=false" >> $GITHUB_OUTPUT
             echo "hostname=alpha.vivliostyle.pub" >> $GITHUB_OUTPUT
+            echo "sandbox-identifier=alpha-vivliostyle-pub" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "preview=true" >> $GITHUB_OUTPUT
             echo "preview-alias=pr-preview-${{ github.event.number }}" >> $GITHUB_OUTPUT
             echo "hostname=pr-preview-${{ github.event.number }}-vivliostyle-pub-app.vivliostyle.workers.dev" >> $GITHUB_OUTPUT
+            echo "sandbox-identifier=pr-preview-${{ github.event.number }}-vivliostyle-pub" >> $GITHUB_OUTPUT
           fi
       - run: pnpm build
         env:
           VITE_APP_HOSTNAME: ${{ steps.build-env.outputs.hostname }}
           VITE_SANDBOX_HOSTNAME: vspub.dev
+          VITE_SANDBOX_SUBDOMAIN_IDENTIFIER: ${{ steps.build-env.outputs.sandbox-identifier }}
 
   deploy:
     needs: build
@@ -59,6 +63,7 @@ jobs:
         env:
           VITE_APP_HOSTNAME: ${{ needs.build.outputs.hostname }}
           VITE_SANDBOX_HOSTNAME: vspub.dev
+          VITE_SANDBOX_SUBDOMAIN_IDENTIFIER: ${{ needs.build.outputs.sandbox-identifier }}
       - name: Deploy production
         if: ${{ github.ref_name == github.event.repository.default_branch }}
         run: npx wrangler deploy

--- a/packages/viola/src/libs/origins.ts
+++ b/packages/viola/src/libs/origins.ts
@@ -16,10 +16,17 @@ export function sandboxBaseOrigin(): string {
     : appOrigin();
 }
 
+// Optional identifier for the sandbox subdomain
+function sandboxSubdomainIdentifier(): string {
+  return import.meta.env.VITE_SANDBOX_SUBDOMAIN_IDENTIFIER
+    ? `--${import.meta.env.VITE_SANDBOX_SUBDOMAIN_IDENTIFIER}`
+    : '';
+}
+
 // Origin for a sandbox subdomain with the given hostname-label prefix, e.g.
 // `sandbox-<projectId>` or `sandbox-ext-<extensionId>`.
 export function sandboxOrigin(label: string): string {
   const url = new URL(sandboxBaseOrigin());
-  url.hostname = `${label}.${url.hostname}`;
+  url.hostname = `${label}${sandboxSubdomainIdentifier()}.${url.hostname}`;
   return url.origin;
 }

--- a/packages/viola/src/vite-env.d.ts
+++ b/packages/viola/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
   readonly VITE_IFRAME_HTML: string;
   readonly VITE_APP_HOSTNAME: string;
   readonly VITE_SANDBOX_HOSTNAME?: string;
+  readonly VITE_SANDBOX_SUBDOMAIN_IDENTIFIER?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Inserts a `--<identifier>` segment into sandbox subdomains so that PR previews and the alpha environment can share the `vspub.dev` sandbox base host without their sandbox origins colliding.

- Add `sandboxSubdomainIdentifier()` in `origins.ts` that reads `VITE_SANDBOX_SUBDOMAIN_IDENTIFIER` and injects a `--<identifier>` segment into `sandboxOrigin()` labels (no-op when unset).
- Derive a per-environment `sandbox-identifier` in `build-deploy.yml` (`alpha-vivliostyle-pub` for the default branch, `pr-preview-<n>-vivliostyle-pub` for PRs) and pass it to both the build and deploy steps via `VITE_SANDBOX_SUBDOMAIN_IDENTIFIER`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)