### PR TITLE
feat(files): add content hashes, signed direct-download URLs, and batch writes

### DIFF
--- a/packages/api-client/src/index.test.ts
+++ b/packages/api-client/src/index.test.ts
@@ -89,6 +89,106 @@ describe('ApiClient', () => {
     expect(files[0]?.path).toBe('a.md');
   });
 
+  it('requests download URLs via the download query flag', async () => {
+    let url = '';
+    const api = new ApiClient({
+      baseUrl: BASE,
+      fetch: mockFetch((req) => {
+        url = req.url;
+        return new Response(
+          JSON.stringify({
+            files: [
+              {
+                path: 'a.md',
+                size: 5,
+                contentType: 'text/markdown',
+                updatedAt: 1,
+                hash: 'deadbeef',
+                downloadUrl: 'https://r2.example/a.md?sig=1',
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }),
+    });
+    const files = await api.listFiles('p1', { download: true });
+    expect(url).toBe(`${BASE}/projects/p1/files?download=true`);
+    expect(files[0]?.hash).toBe('deadbeef');
+    expect(files[0]?.downloadUrl).toBe('https://r2.example/a.md?sig=1');
+  });
+
+  it('batch-writes files as multipart and returns the entries', async () => {
+    let method = '';
+    let url = '';
+    let auth: string | null = null;
+    const names: string[] = [];
+    const deletes: string[] = [];
+    const api = new ApiClient({
+      baseUrl: BASE,
+      getAccessToken: () => 'tok',
+      fetch: mockFetch(async (req) => {
+        method = req.method;
+        url = req.url;
+        auth = req.headers.get('Authorization');
+        const form = await req.formData();
+        for (const [name, value] of form.entries()) {
+          if (name === '$delete') deletes.push(value as string);
+          else names.push(name);
+        }
+        return new Response(
+          JSON.stringify({
+            files: [
+              {
+                path: 'a.md',
+                size: 5,
+                contentType: 'text/markdown',
+                updatedAt: 1,
+                hash: 'h',
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }),
+    });
+    const result = await api.writeFiles('p1', {
+      writes: [
+        {
+          path: 'a.md',
+          data: new Uint8Array([1]),
+          contentType: 'text/markdown',
+        },
+        { path: 'css/b.css', data: new Uint8Array([2]) },
+      ],
+      deletes: ['old.md'],
+    });
+    expect(method).toBe('POST');
+    expect(url).toBe(`${BASE}/projects/p1/files`);
+    expect(auth).toBe('Bearer tok');
+    expect(names.sort()).toEqual(['a.md', 'css/b.css']);
+    expect(deletes).toEqual(['old.md']);
+    expect(result[0]?.hash).toBe('h');
+  });
+
+  it('fetches a download URL without attaching the bearer token', async () => {
+    let auth: string | null = 'unset';
+    let url = '';
+    const api = new ApiClient({
+      baseUrl: BASE,
+      getAccessToken: () => 'tok',
+      fetch: mockFetch((req) => {
+        auth = req.headers.get('Authorization');
+        url = req.url;
+        return new Response(new Uint8Array([4, 2]), { status: 200 });
+      }),
+    });
+    const bytes = await api.fetchDownloadUrl('https://r2.example/a.md?sig=1');
+    expect(url).toBe('https://r2.example/a.md?sig=1');
+    expect(auth).toBeNull();
+    expect(bytes).toEqual(new Uint8Array([4, 2]));
+  });
+
   it('round-trips binary sync payloads', async () => {
     let seenUrl = '';
     const api = new ApiClient({

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -190,15 +190,85 @@ export class ApiClient {
     }
   }
 
-  async listFiles(projectId: string): Promise<FileEntry[]> {
+  async listFiles(
+    projectId: string,
+    options?: { download?: boolean },
+  ): Promise<FileEntry[]> {
     const { data, error, response } = await this.client.GET(
       '/projects/{id}/files',
-      { params: { path: { id: projectId } } },
+      {
+        params: {
+          path: { id: projectId },
+          query: options?.download ? { download: true } : undefined,
+        },
+      },
     );
     if (!response.ok || !data) {
       throw new ApiError('Failed to list files', response.status, error);
     }
     return data.files;
+  }
+
+  /**
+   * Create/replace and delete several files in one request. Returns the
+   * resulting entries (with hashes) for the written files. Avoids the
+   * per-file round-trip of repeated {@link writeFile}/{@link deleteFile} calls.
+   */
+  async writeFiles(
+    projectId: string,
+    changes: {
+      writes?: { path: string; data: Uint8Array; contentType?: string }[];
+      deletes?: string[];
+    },
+  ): Promise<FileEntry[]> {
+    const form = new FormData();
+    for (const write of changes.writes ?? []) {
+      const copy = new Uint8Array(write.data.byteLength);
+      copy.set(write.data);
+      form.append(
+        write.path,
+        new Blob([copy.buffer], {
+          type: write.contentType ?? 'application/octet-stream',
+        }),
+        write.path.split('/').pop() || write.path,
+      );
+    }
+    for (const path of changes.deletes ?? []) {
+      form.append('$delete', path);
+    }
+    const token = await this.getAccessToken?.();
+    const response = await this.fetchImpl(
+      `${this.baseUrl}/projects/${encodeURIComponent(projectId)}/files`,
+      {
+        method: 'POST',
+        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        body: form,
+      },
+    );
+    if (!response.ok) {
+      let body: unknown;
+      try {
+        body = await response.json();
+      } catch {
+        body = undefined;
+      }
+      throw new ApiError('Failed to write files', response.status, body);
+    }
+    const data = (await response.json()) as { files: FileEntry[] };
+    return data.files;
+  }
+
+  /**
+   * Fetch bytes from a direct-download URL handed out by {@link listFiles} with
+   * `download: true`. The URL is self-authenticating (presigned / signed), so
+   * no bearer token is attached.
+   */
+  async fetchDownloadUrl(url: string): Promise<Uint8Array> {
+    const response = await this.fetchImpl(url);
+    if (!response.ok) {
+      throw new ApiError('Failed to download file', response.status);
+    }
+    return new Uint8Array(await response.arrayBuffer());
   }
 
   async readFile(

--- a/packages/api-client/src/schema.d.ts
+++ b/packages/api-client/src/schema.d.ts
@@ -249,9 +249,33 @@ export interface paths {
         };
         /**
          * List files
-         * @description Returns every file currently stored in the project.
+         * @description Returns every file currently stored in the project, each with a SHA-256 `hash` of its content. Pass `download=true` to also receive a short-lived `downloadUrl` for fetching each file directly, bypassing this API.
          */
         get: operations["getProjectsByIdFiles"];
+        put?: never;
+        /**
+         * Write files (batch)
+         * @description Creates or replaces multiple files and deletes others in a single request, to avoid one round-trip per file. Send `multipart/form-data` where each file part is named by its project-relative path, and each form field named `$delete` carries one path to remove. Returns the resulting entries (with hashes) for the written files.
+         */
+        post: operations["postProjectsByIdFiles"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/files-download/{id}/{path}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Download a file via a signed URL
+         * @description Returns the file's raw bytes for a URL minted by the file listing's `download=true` mode. Authorized by the `exp`/`sig` query pair rather than a bearer token.
+         */
+        get: operations["getFilesDownloadByIdByPath"];
         put?: never;
         post?: never;
         delete?: never;
@@ -899,7 +923,10 @@ export interface operations {
     };
     getProjectsByIdFiles: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description When `true`, include a short-lived direct-download URL on every entry. */
+                download?: boolean;
+            };
             header?: never;
             path: {
                 id: string;
@@ -920,7 +947,108 @@ export interface operations {
                             size: number;
                             contentType: string;
                             updatedAt: number;
+                            hash?: string;
+                            downloadUrl?: string;
                         }[];
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    postProjectsByIdFiles: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "multipart/form-data": {
+                    /** @description Project-relative paths to delete. */
+                    $delete?: string[];
+                } & {
+                    [key: string]: Uint8Array;
+                };
+            };
+        };
+        responses: {
+            /** @description Written files */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        files: {
+                            path: string;
+                            size: number;
+                            contentType: string;
+                            updatedAt: number;
+                            hash?: string;
+                            downloadUrl?: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    getFilesDownloadByIdByPath: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description File contents */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/octet-stream": Uint8Array;
+                };
+            };
+            /** @description Invalid signature */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
                     };
                 };
             };

--- a/packages/api-server-reference/src/app.test.ts
+++ b/packages/api-server-reference/src/app.test.ts
@@ -439,6 +439,73 @@ describe('files', () => {
     );
     expect(await get.text()).toBe('cover');
   });
+
+  it('lists files with a content hash and a signed download URL', async () => {
+    await app.request(`/projects/${projectId}/files/a.md`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'text/markdown', ...bearer(token) },
+      body: 'alpha',
+    });
+    const list = await app.request(
+      `/projects/${projectId}/files?download=true`,
+      { headers: bearer(token) },
+    );
+    const { files } = await readJson<{
+      files: { path: string; hash?: string; downloadUrl?: string }[];
+    }>(list);
+    expect(files[0].hash).toBe(sha256Hex(new TextEncoder().encode('alpha')));
+    expect(files[0].downloadUrl).toBeTruthy();
+
+    // The signed URL serves the bytes without a bearer token.
+    const url = new URL(files[0].downloadUrl as string);
+    const ok = await app.request(`${url.pathname}${url.search}`);
+    expect(ok.status).toBe(200);
+    expect(await ok.text()).toBe('alpha');
+
+    // A tampered signature is rejected.
+    const tampered = await app.request(
+      `${url.pathname}?exp=${url.searchParams.get('exp')}&sig=forged`,
+    );
+    expect(tampered.status).toBe(403);
+  });
+
+  it('batch-writes and deletes files in one request', async () => {
+    const form = new FormData();
+    form.append('a.md', new Blob(['alpha'], { type: 'text/markdown' }), 'a.md');
+    form.append(
+      'css/b.css',
+      new Blob(['body{}'], { type: 'text/css' }),
+      'b.css',
+    );
+    const res = await app.request(`/projects/${projectId}/files`, {
+      method: 'POST',
+      headers: bearer(token),
+      body: form,
+    });
+    expect(res.status).toBe(200);
+    const { files } = await readJson<{
+      files: { path: string; hash?: string }[];
+    }>(res);
+    expect(files.map((f) => f.path).sort()).toEqual(['a.md', 'css/b.css']);
+    expect(files.find((f) => f.path === 'a.md')?.hash).toBe(
+      sha256Hex(new TextEncoder().encode('alpha')),
+    );
+
+    const del = new FormData();
+    del.append('$delete', 'a.md');
+    const delRes = await app.request(`/projects/${projectId}/files`, {
+      method: 'POST',
+      headers: bearer(token),
+      body: del,
+    });
+    expect(delRes.status).toBe(200);
+
+    const list = await app.request(`/projects/${projectId}/files`, {
+      headers: bearer(token),
+    });
+    const after = (await readJson<{ files: { path: string }[] }>(list)).files;
+    expect(after.map((f) => f.path)).toEqual(['css/b.css']);
+  });
 });
 
 describe('attachments', () => {

--- a/packages/api-server-reference/src/crypto.ts
+++ b/packages/api-server-reference/src/crypto.ts
@@ -1,5 +1,6 @@
 import {
   createHash,
+  createHmac,
   randomBytes,
   randomUUID,
   scryptSync,
@@ -45,4 +46,38 @@ export function verifyPkce(verifier: string, challenge: string): boolean {
   const a = Buffer.from(computed);
   const b = Buffer.from(challenge);
   return a.length === b.length && timingSafeEqual(a, b);
+}
+
+/**
+ * HMAC that authorizes a single direct file download (the reference server's
+ * stand-in for an object-store presigned URL): it binds the project, path, and
+ * expiry so the unauthenticated download route can serve the bytes without a
+ * bearer token while still scoping access to exactly one file for a short time.
+ */
+export function signDownloadToken(
+  secret: string,
+  projectId: string,
+  filePath: string,
+  expiresAt: number,
+): string {
+  return createHmac('sha256', secret)
+    .update(`${projectId}\n${filePath}\n${expiresAt}`)
+    .digest('base64url');
+}
+
+export function verifyDownloadToken(
+  secret: string,
+  projectId: string,
+  filePath: string,
+  expiresAt: number,
+  signature: string,
+): boolean {
+  if (!Number.isFinite(expiresAt) || expiresAt < Date.now()) {
+    return false;
+  }
+  const expected = Buffer.from(
+    signDownloadToken(secret, projectId, filePath, expiresAt),
+  );
+  const actual = Buffer.from(signature);
+  return expected.length === actual.length && timingSafeEqual(expected, actual);
 }

--- a/packages/api-server-reference/src/deps.ts
+++ b/packages/api-server-reference/src/deps.ts
@@ -1,3 +1,4 @@
+import { randomToken } from './crypto';
 import type { FileStore } from './storage/file-store';
 import type { SqliteStore } from './storage/sqlite-store';
 import type { DocRegistry } from './sync/doc-registry';
@@ -9,6 +10,10 @@ export interface ServerConfig {
   refreshTokenTtlMs: number;
   authCodeTtlMs: number;
   sessionTtlMs: number;
+  /** HMAC secret backing the signed direct-download URLs. */
+  downloadUrlSecret: string;
+  /** How long a signed direct-download URL stays valid. */
+  downloadUrlTtlMs: number;
 }
 
 export const defaultConfig: ServerConfig = {
@@ -18,6 +23,10 @@ export const defaultConfig: ServerConfig = {
   refreshTokenTtlMs: 30 * 24 * 60 * 60 * 1000, // 30 days
   authCodeTtlMs: 5 * 60 * 1000, // 5 minutes
   sessionTtlMs: 7 * 24 * 60 * 60 * 1000, // 7 days
+  // Regenerated per process unless overridden; signed URLs are short-lived, so
+  // a fresh secret on restart only invalidates URLs already handed out.
+  downloadUrlSecret: randomToken(),
+  downloadUrlTtlMs: 5 * 60 * 1000, // 5 minutes
 };
 
 export interface Deps {

--- a/packages/api-server-reference/src/openapi.ts
+++ b/packages/api-server-reference/src/openapi.ts
@@ -78,11 +78,13 @@ export async function generateSpec(app: Hono) {
     documentation: openApiDocumentation(),
   });
   // hono-openapi documents every `validator('form', …)` body as
-  // `multipart/form-data`, but these are OAuth2 endpoints whose clients send
-  // `application/x-www-form-urlencoded` (this API has no multipart upload), so
-  // relabel them to match the wire format. The plugin's `media` override option
-  // can't be used: in 1.3.0 it mis-parses and yields `application/json`.
-  for (const pathItem of Object.values(spec.paths ?? {})) {
+  // `multipart/form-data`, but the OAuth2 endpoints' clients send
+  // `application/x-www-form-urlencoded`, so relabel those to match the wire
+  // format. The plugin's `media` override option can't be used: in 1.3.0 it
+  // mis-parses and yields `application/json`. The batch file-write endpoint is
+  // genuine multipart, so this is scoped to `/auth/*` to leave it untouched.
+  for (const [path, pathItem] of Object.entries(spec.paths ?? {})) {
+    if (!path.startsWith('/auth')) continue;
     for (const operation of Object.values(pathItem ?? {})) {
       const content = (
         operation as {

--- a/packages/api-server-reference/src/routes/files.ts
+++ b/packages/api-server-reference/src/routes/files.ts
@@ -1,23 +1,65 @@
 import { Hono } from 'hono';
 import { describeRoute } from 'hono-openapi';
 
+import { signDownloadToken, verifyDownloadToken } from '../crypto';
 import type { AuthEnv, Deps } from '../deps';
 import { binaryContent, jsonContent, toArrayBuffer } from '../http-helpers';
-import { ErrorSchema, FileListSchema } from '../schemas';
+import { ErrorSchema, type FileEntry, FileListSchema } from '../schemas';
 
-export function fileRoutes({ store, files, docs }: Deps) {
+function encodeFilePath(filePath: string): string {
+  return filePath.split('/').map(encodeURIComponent).join('/');
+}
+
+// Field name carrying the paths to delete in a batch request; chosen so it
+// cannot collide with a real file path (which never starts with `$`).
+const BATCH_DELETE_FIELD = '$delete';
+
+export function fileRoutes({ store, files, docs, config }: Deps) {
   const app = new Hono<AuthEnv>();
 
   const owns = (userId: string, projectId: string) =>
     store.getProject(userId, projectId) !== undefined;
+
+  // The reference server has no separate object store to offload egress to, so
+  // it mints a short-lived HMAC-signed URL to its own unauthenticated download
+  // route. This mirrors the wire contract an R2-backed server fulfils with a
+  // presigned URL: the client fetches the bytes without a bearer token, and
+  // access is scoped to one file for `downloadUrlTtlMs`.
+  const buildDownloadUrl = (
+    c: { req: { url: string } },
+    projectId: string,
+    filePath: string,
+  ): string => {
+    const expiresAt = Date.now() + config.downloadUrlTtlMs;
+    const sig = signDownloadToken(
+      config.downloadUrlSecret,
+      projectId,
+      filePath,
+      expiresAt,
+    );
+    const origin = new URL(c.req.url).origin;
+    const query = `exp=${expiresAt}&sig=${encodeURIComponent(sig)}`;
+    return `${origin}/files-download/${encodeURIComponent(projectId)}/${encodeFilePath(filePath)}?${query}`;
+  };
 
   app.get(
     '/projects/:id/files',
     describeRoute({
       tags: ['files'],
       summary: 'List files',
-      description: 'Returns every file currently stored in the project.',
+      description:
+        'Returns every file currently stored in the project, each with a SHA-256 `hash` of its content. Pass `download=true` to also receive a short-lived `downloadUrl` for fetching each file directly, bypassing this API.',
       security: [{ bearerAuth: [] }],
+      parameters: [
+        {
+          name: 'download',
+          in: 'query',
+          required: false,
+          description:
+            'When `true`, include a short-lived direct-download URL on every entry.',
+          schema: { type: 'boolean' },
+        },
+      ],
       responses: {
         200: { description: 'Files', content: jsonContent(FileListSchema) },
         404: { description: 'Not found', content: jsonContent(ErrorSchema) },
@@ -28,7 +70,115 @@ export function fileRoutes({ store, files, docs }: Deps) {
       if (!owns(c.get('userId'), projectId)) {
         return c.json({ error: 'not_found' }, 404);
       }
-      return c.json({ files: await files.listFiles(projectId) }, 200);
+      const entries = await files.listFiles(projectId);
+      if (c.req.query('download') === 'true') {
+        for (const entry of entries) {
+          entry.downloadUrl = buildDownloadUrl(c, projectId, entry.path);
+        }
+      }
+      return c.json({ files: entries }, 200);
+    },
+  );
+
+  app.post(
+    '/projects/:id/files',
+    describeRoute({
+      tags: ['files'],
+      summary: 'Write files (batch)',
+      description:
+        'Creates or replaces multiple files and deletes others in a single request, to avoid one round-trip per file. Send `multipart/form-data` where each file part is named by its project-relative path, and each form field named `$delete` carries one path to remove. Returns the resulting entries (with hashes) for the written files.',
+      security: [{ bearerAuth: [] }],
+      requestBody: {
+        content: {
+          'multipart/form-data': {
+            schema: {
+              type: 'object',
+              properties: {
+                $delete: {
+                  type: 'array',
+                  items: { type: 'string' },
+                  description: 'Project-relative paths to delete.',
+                },
+              },
+              additionalProperties: { type: 'string', format: 'binary' },
+            },
+          },
+        },
+      },
+      responses: {
+        200: {
+          description: 'Written files',
+          content: jsonContent(FileListSchema),
+        },
+        404: { description: 'Not found', content: jsonContent(ErrorSchema) },
+      },
+    }),
+    async (c) => {
+      const projectId = c.req.param('id');
+      if (!owns(c.get('userId'), projectId)) {
+        return c.json({ error: 'not_found' }, 404);
+      }
+      const form = await c.req.formData();
+      const written: FileEntry[] = [];
+      for (const [name, value] of form.entries()) {
+        if (name === BATCH_DELETE_FIELD || typeof value === 'string') {
+          continue;
+        }
+        const data = new Uint8Array(await value.arrayBuffer());
+        written.push(await files.writeFile(projectId, name, data));
+      }
+      for (const path of form.getAll(BATCH_DELETE_FIELD)) {
+        if (typeof path !== 'string') continue;
+        if (await files.removeFile(projectId, path)) {
+          store.deleteDocState(projectId, path);
+          docs.evict(projectId, path);
+        }
+      }
+      return c.json({ files: written }, 200);
+    },
+  );
+
+  // Unauthenticated: the signed `exp`/`sig` query pair scopes access to a single
+  // file for a short window, standing in for an object-store presigned URL.
+  app.get(
+    '/files-download/:id/:path{.+}',
+    describeRoute({
+      tags: ['files'],
+      summary: 'Download a file via a signed URL',
+      description:
+        "Returns the file's raw bytes for a URL minted by the file listing's `download=true` mode. Authorized by the `exp`/`sig` query pair rather than a bearer token.",
+      responses: {
+        200: { description: 'File contents', content: binaryContent },
+        403: {
+          description: 'Invalid signature',
+          content: jsonContent(ErrorSchema),
+        },
+        404: { description: 'Not found', content: jsonContent(ErrorSchema) },
+      },
+    }),
+    async (c) => {
+      const projectId = c.req.param('id');
+      const filePath = c.req.param('path');
+      const expiresAt = Number(c.req.query('exp'));
+      const sig = c.req.query('sig') ?? '';
+      if (
+        !verifyDownloadToken(
+          config.downloadUrlSecret,
+          projectId,
+          filePath,
+          expiresAt,
+          sig,
+        )
+      ) {
+        return c.json({ error: 'forbidden' }, 403);
+      }
+      const file = await files.readFile(projectId, filePath);
+      if (!file) {
+        return c.json({ error: 'not_found' }, 404);
+      }
+      return c.body(toArrayBuffer(file.data), 200, {
+        'Content-Type': file.contentType,
+      });
     },
   );
 

--- a/packages/api-server-reference/src/schemas.ts
+++ b/packages/api-server-reference/src/schemas.ts
@@ -112,6 +112,14 @@ export const FileEntrySchema = v.object({
   size: v.number(),
   contentType: v.string(),
   updatedAt: v.number(),
+  // SHA-256 hex of the file content. Lets a client diff its local copy against
+  // the server and upload only the files that actually changed. Optional so a
+  // backend that cannot derive it cheaply may omit it.
+  hash: v.optional(v.string()),
+  // Short-lived URL for fetching the bytes directly from the underlying blob
+  // store, bypassing this API. Present only when the listing was requested with
+  // `download=true`, and only for backends that can mint one.
+  downloadUrl: v.optional(v.string()),
 });
 export type FileEntry = v.InferOutput<typeof FileEntrySchema>;
 

--- a/packages/api-server-reference/src/storage/file-store.ts
+++ b/packages/api-server-reference/src/storage/file-store.ts
@@ -2,6 +2,7 @@ import * as nodeFs from 'node:fs/promises';
 import { create as createVfs, type VirtualFileSystem } from '@platformatic/vfs';
 import { dirname, join, normalize } from 'pathe';
 
+import { sha256Hex } from '../crypto';
 import type { FileEntry } from '../schemas';
 
 const MIME_BY_EXT: Record<string, string> = {
@@ -176,6 +177,7 @@ export class FileStore {
       size: stat.size,
       contentType: guessMimeType(rel),
       updatedAt: Math.floor(stat.mtimeMs),
+      hash: sha256Hex(data),
     };
   }
 
@@ -248,11 +250,13 @@ export class FileStore {
         await this.walkFiles(child, rel, out);
       } else if (entry.isFile()) {
         const stat = await this.fs.stat(child);
+        const data = await this.fs.readFile(child);
         out.push({
           path: rel,
           size: stat.size,
           contentType: guessMimeType(rel),
           updatedAt: Math.floor(stat.mtimeMs),
+          hash: sha256Hex(toUint8Array(data)),
         });
       }
     }

--- a/packages/api-spec/src/openapi.yaml
+++ b/packages/api-spec/src/openapi.yaml
@@ -802,9 +802,25 @@ paths:
       tags:
         - files
       summary: List files
-      description: Returns every file currently stored in the project.
+      description: Returns every file currently stored in the project, each with a
+        SHA-256 `hash` of its content. Pass `download=true` to also receive a
+        short-lived `downloadUrl` for fetching each file directly, bypassing
+        this API.
       security:
         - bearerAuth: []
+      parameters:
+        - name: download
+          in: query
+          required: false
+          description: When `true`, include a short-lived direct-download URL on every
+            entry.
+          schema:
+            type: boolean
+        - schema:
+            type: string
+          in: path
+          name: id
+          required: true
       responses:
         "200":
           description: Files
@@ -826,6 +842,81 @@ paths:
                           type: string
                         updatedAt:
                           type: number
+                        hash:
+                          type: string
+                        downloadUrl:
+                          type: string
+                      required:
+                        - path
+                        - size
+                        - contentType
+                        - updatedAt
+                required:
+                  - files
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                required:
+                  - error
+    post:
+      operationId: postProjectsByIdFiles
+      tags:
+        - files
+      summary: Write files (batch)
+      description: Creates or replaces multiple files and deletes others in a single
+        request, to avoid one round-trip per file. Send `multipart/form-data`
+        where each file part is named by its project-relative path, and each
+        form field named `$delete` carries one path to remove. Returns the
+        resulting entries (with hashes) for the written files.
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                $delete:
+                  type: array
+                  items:
+                    type: string
+                  description: Project-relative paths to delete.
+              additionalProperties:
+                type: string
+                format: binary
+      responses:
+        "200":
+          description: Written files
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  files:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        path:
+                          type: string
+                        size:
+                          type: number
+                        contentType:
+                          type: string
+                        updatedAt:
+                          type: number
+                        hash:
+                          type: string
+                        downloadUrl:
+                          type: string
                       required:
                         - path
                         - size
@@ -851,6 +942,56 @@ paths:
             type: string
           in: path
           name: id
+          required: true
+  /files-download/{id}/{path}:
+    get:
+      operationId: getFilesDownloadByIdByPath
+      tags:
+        - files
+      summary: Download a file via a signed URL
+      description: Returns the file's raw bytes for a URL minted by the file listing's
+        `download=true` mode. Authorized by the `exp`/`sig` query pair rather
+        than a bearer token.
+      responses:
+        "200":
+          description: File contents
+          content: *a1
+        "403":
+          description: Invalid signature
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                required:
+                  - error
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                required:
+                  - error
+      parameters:
+        - schema:
+            type: string
+          in: path
+          name: id
+          required: true
+        - schema:
+            type: string
+          in: path
+          name: path
           required: true
   /projects/{id}/files/{path}:
     get:

--- a/packages/storage-providers/src/providers/remote-http.test.ts
+++ b/packages/storage-providers/src/providers/remote-http.test.ts
@@ -3,16 +3,40 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { StorageNotFoundError } from '../errors';
 import { type RemoteFileApi, RemoteHttpStorageProvider } from './remote-http';
 
+async function sha256Hex(data: Uint8Array): Promise<string> {
+  const buffer = new ArrayBuffer(data.byteLength);
+  new Uint8Array(buffer).set(data);
+  const digest = await crypto.subtle.digest('SHA-256', buffer);
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
 class FakeFileApi implements RemoteFileApi {
   private files = new Map<string, { data: Uint8Array; contentType: string }>();
+  writeFileCalls = 0;
+  writeFilesCalls = 0;
+  downloadUrlFetches = 0;
 
-  async listFiles(_projectId: string) {
-    return [...this.files.entries()].map(([path, file]) => ({
+  private async entry(path: string, download: boolean) {
+    const file = this.files.get(path);
+    if (!file) throw new Error(`missing ${path}`);
+    return {
       path,
       size: file.data.byteLength,
       contentType: file.contentType,
       updatedAt: 1,
-    }));
+      hash: await sha256Hex(file.data),
+      ...(download ? { downloadUrl: `mem://${encodeURIComponent(path)}` } : {}),
+    };
+  }
+
+  async listFiles(_projectId: string, options?: { download?: boolean }) {
+    return Promise.all(
+      [...this.files.keys()].map((path) =>
+        this.entry(path, options?.download ?? false),
+      ),
+    );
   }
 
   async readFile(_projectId: string, path: string) {
@@ -25,11 +49,42 @@ class FakeFileApi implements RemoteFileApi {
     data: Uint8Array,
     contentType = 'application/octet-stream',
   ) {
+    this.writeFileCalls++;
     this.files.set(path, { data, contentType });
+  }
+
+  async writeFiles(
+    _projectId: string,
+    changes: {
+      writes?: { path: string; data: Uint8Array; contentType?: string }[];
+      deletes?: string[];
+    },
+  ) {
+    this.writeFilesCalls++;
+    for (const write of changes.writes ?? []) {
+      this.files.set(write.path, {
+        data: write.data,
+        contentType: write.contentType ?? 'application/octet-stream',
+      });
+    }
+    for (const path of changes.deletes ?? []) {
+      this.files.delete(path);
+    }
+    return Promise.all(
+      (changes.writes ?? []).map((write) => this.entry(write.path, false)),
+    );
   }
 
   async deleteFile(_projectId: string, path: string) {
     this.files.delete(path);
+  }
+
+  async fetchDownloadUrl(url: string) {
+    this.downloadUrlFetches++;
+    const path = decodeURIComponent(url.replace('mem://', ''));
+    const file = this.files.get(path);
+    if (!file) throw new Error(`missing ${path}`);
+    return file.data;
   }
 }
 
@@ -116,5 +171,66 @@ describe('RemoteHttpStorageProvider', () => {
     );
     expect(await provider.exists('old.md')).toBe(false);
     expect(dec(await provider.read('new.md'))).toBe('new');
+  });
+
+  it('applies a batch of writes and deletes in one request', async () => {
+    await provider.write('keep.md', enc('keep'));
+    expect(api.writeFileCalls).toBe(1);
+
+    await provider.applyBatch({
+      writes: [
+        { path: 'a.md', data: enc('alpha') },
+        { path: 'nested/b.css', data: enc('body{}') },
+      ],
+      deletes: ['keep.md'],
+    });
+
+    expect(api.writeFilesCalls).toBe(1);
+    expect(dec(await provider.read('a.md'))).toBe('alpha');
+    expect((await provider.stat('a.md'))?.mimeType).toBe('text/markdown');
+    expect(await provider.exists('keep.md')).toBe(false);
+  });
+
+  it('reads many files through direct-download URLs', async () => {
+    await provider.write('a.md', enc('alpha'));
+    await provider.write('b.md', enc('beta'));
+
+    const bytes = await provider.readMany(['a.md', 'b.md', 'missing.md']);
+    expect(dec(bytes.get('a.md') as Uint8Array)).toBe('alpha');
+    expect(dec(bytes.get('b.md') as Uint8Array)).toBe('beta');
+    expect(bytes.has('missing.md')).toBe(false);
+    expect(api.downloadUrlFetches).toBe(2);
+  });
+
+  it('restore uploads only the files whose content changed', async () => {
+    await provider.write('a.md', enc('alpha'));
+    await provider.write('b.md', enc('beta'));
+    const baseline = api.writeFilesCalls;
+
+    await provider.restore('', {
+      format: 'memfs-json',
+      data: {
+        '/a.md': enc('alpha'), // unchanged → skipped
+        '/b.md': enc('BETA'), // changed → uploaded
+        '/c.md': enc('gamma'), // new → uploaded
+      },
+    });
+
+    expect(api.writeFilesCalls).toBe(baseline + 1);
+    expect(dec(await provider.read('a.md'))).toBe('alpha');
+    expect(dec(await provider.read('b.md'))).toBe('BETA');
+    expect(dec(await provider.read('c.md'))).toBe('gamma');
+  });
+
+  it('makes no request when restore finds nothing changed', async () => {
+    await provider.write('a.md', enc('alpha'));
+    const baseline = api.writeFilesCalls;
+
+    await provider.restore('', {
+      format: 'memfs-json',
+      data: { '/a.md': enc('alpha') },
+    });
+
+    expect(api.writeFilesCalls).toBe(baseline);
   });
 });

--- a/packages/storage-providers/src/providers/remote-http.ts
+++ b/packages/storage-providers/src/providers/remote-http.ts
@@ -2,6 +2,7 @@ import { join } from 'pathe';
 
 import { StorageError, StorageNotFoundError } from '../errors';
 import type {
+  BatchChanges,
   FileMeta,
   ListEntry,
   ListOptions,
@@ -20,6 +21,16 @@ interface RemoteFileEntry {
   size: number;
   contentType: string;
   updatedAt: number;
+  /** SHA-256 hex of the content, when the server provides it. */
+  hash?: string;
+  /** Short-lived URL for fetching the bytes directly, when requested. */
+  downloadUrl?: string;
+}
+
+interface RemoteFileWrite {
+  path: string;
+  data: Uint8Array;
+  contentType?: string;
 }
 
 /**
@@ -27,7 +38,10 @@ interface RemoteFileEntry {
  * `ApiClient` satisfies this structurally.
  */
 export interface RemoteFileApi {
-  listFiles(projectId: string): Promise<RemoteFileEntry[]>;
+  listFiles(
+    projectId: string,
+    options?: { download?: boolean },
+  ): Promise<RemoteFileEntry[]>;
   readFile(projectId: string, path: string): Promise<Uint8Array | null>;
   writeFile(
     projectId: string,
@@ -35,7 +49,29 @@ export interface RemoteFileApi {
     data: Uint8Array,
     contentType?: string,
   ): Promise<void>;
+  writeFiles(
+    projectId: string,
+    changes: { writes?: RemoteFileWrite[]; deletes?: string[] },
+  ): Promise<RemoteFileEntry[]>;
   deleteFile(projectId: string, path: string): Promise<void>;
+  fetchDownloadUrl(url: string): Promise<Uint8Array>;
+}
+
+async function sha256Hex(data: Uint8Array): Promise<string> {
+  const buffer = new ArrayBuffer(data.byteLength);
+  new Uint8Array(buffer).set(data);
+  const digest = await crypto.subtle.digest('SHA-256', buffer);
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function hasStatus(error: unknown, status: number): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { status?: unknown }).status === status
+  );
 }
 
 const MIME_BY_EXT: Record<string, string> = {
@@ -129,6 +165,78 @@ export class RemoteHttpStorageProvider implements StorageProvider {
     } catch (cause) {
       throw new StorageError(`Failed to write ${path}`, { cause });
     }
+  }
+
+  async applyBatch(changes: BatchChanges): Promise<void> {
+    const writes: RemoteFileWrite[] = (changes.writes ?? []).map((write) => ({
+      path: normalize(write.path),
+      data: write.data,
+      contentType: write.mimeType ?? guessMimeType(write.path),
+    }));
+    const deletes = (changes.deletes ?? []).map(normalize);
+    if (writes.length === 0 && deletes.length === 0) {
+      return;
+    }
+    try {
+      await this.api.writeFiles(this.projectId, { writes, deletes });
+    } catch (cause) {
+      // Older servers without the batch endpoint answer 404; fall back to the
+      // per-file endpoints so a version skew still completes.
+      if (!hasStatus(cause, 404)) {
+        throw new StorageError('Failed to write files', { cause });
+      }
+      await Promise.all([
+        ...writes.map((write) =>
+          this.api.writeFile(
+            this.projectId,
+            write.path,
+            write.data,
+            write.contentType,
+          ),
+        ),
+        ...deletes.map((path) => this.api.deleteFile(this.projectId, path)),
+      ]);
+    }
+  }
+
+  async readMany(paths: readonly string[]): Promise<Map<string, Uint8Array>> {
+    const result = new Map<string, Uint8Array>();
+    if (paths.length === 0) {
+      return result;
+    }
+    const wanted = new Set(paths.map(normalize));
+    let entries: RemoteFileEntry[];
+    try {
+      entries = await this.api.listFiles(this.projectId, { download: true });
+    } catch (cause) {
+      throw new StorageError('Failed to list files', { cause });
+    }
+    await Promise.all(
+      entries
+        .filter((entry) => wanted.has(entry.path))
+        .map(async (entry) => {
+          const bytes = await this.fetchEntryBytes(entry);
+          if (bytes) {
+            result.set(entry.path, bytes);
+          }
+        }),
+    );
+    return result;
+  }
+
+  // Prefer the direct-download URL (free egress, no API hop) and fall back to
+  // the API byte endpoint when the server did not hand one out.
+  private async fetchEntryBytes(
+    entry: RemoteFileEntry,
+  ): Promise<Uint8Array | null> {
+    if (entry.downloadUrl) {
+      try {
+        return await this.api.fetchDownloadUrl(entry.downloadUrl);
+      } catch {
+        // fall through to the API endpoint
+      }
+    }
+    return this.api.readFile(this.projectId, entry.path);
   }
 
   async remove(path: string, options?: RemoveOptions): Promise<void> {
@@ -234,14 +342,16 @@ export class RemoteHttpStorageProvider implements StorageProvider {
     const normalized = normalize(path);
     const prefix = normalized ? `${normalized}/` : '';
     const ignore = options?.ignore ?? [];
-    const files = await this.api.listFiles(this.projectId);
+    const entries = await this.api.listFiles(this.projectId, {
+      download: true,
+    });
     const data: Record<string, Uint8Array> = {};
     await Promise.all(
-      files.map(async (file) => {
-        if (prefix && !file.path.startsWith(prefix)) {
+      entries.map(async (entry) => {
+        if (prefix && !entry.path.startsWith(prefix)) {
           return;
         }
-        const rel = file.path.slice(prefix.length);
+        const rel = entry.path.slice(prefix.length);
         if (!rel) {
           return;
         }
@@ -250,7 +360,7 @@ export class RemoteHttpStorageProvider implements StorageProvider {
         if (ignore.some((re) => re.test(rel))) {
           return;
         }
-        const bytes = await this.api.readFile(this.projectId, file.path);
+        const bytes = await this.fetchEntryBytes(entry);
         if (bytes) {
           data[`/${rel}`] = bytes;
         }
@@ -270,9 +380,7 @@ export class RemoteHttpStorageProvider implements StorageProvider {
       );
     }
     const prefix = normalize(path);
-    if (options?.clean) {
-      await this.remove(prefix, { recursive: true });
-    }
+    const desired = new Map<string, Uint8Array>();
     for (const [filePath, content] of Object.entries(snapshot.data)) {
       if (content === null) {
         continue;
@@ -280,11 +388,50 @@ export class RemoteHttpStorageProvider implements StorageProvider {
       const targetPath = prefix
         ? join(prefix, normalize(filePath))
         : normalize(filePath);
-      const bytes =
+      desired.set(
+        targetPath,
         typeof content === 'string'
           ? new TextEncoder().encode(content)
-          : content;
-      await this.write(targetPath, bytes);
+          : content,
+      );
     }
+
+    // Diff against the server so unchanged files are not re-uploaded.
+    let serverEntries: RemoteFileEntry[] = [];
+    try {
+      serverEntries = await this.api.listFiles(this.projectId);
+    } catch {
+      // Treat an unreadable listing as an empty project: upload everything.
+    }
+    const serverHashes = new Map(
+      serverEntries.map((entry) => [entry.path, entry.hash]),
+    );
+
+    const writes: { path: string; data: Uint8Array }[] = [];
+    for (const [targetPath, bytes] of desired) {
+      const existing = serverHashes.get(targetPath);
+      if (existing && existing === (await sha256Hex(bytes))) {
+        continue;
+      }
+      writes.push({ path: targetPath, data: bytes });
+    }
+
+    const deletes: string[] = [];
+    if (options?.clean) {
+      for (const entry of serverEntries) {
+        if (
+          prefix &&
+          entry.path !== prefix &&
+          !entry.path.startsWith(`${prefix}/`)
+        ) {
+          continue;
+        }
+        if (!desired.has(entry.path)) {
+          deletes.push(entry.path);
+        }
+      }
+    }
+
+    await this.applyBatch({ writes, deletes });
   }
 }

--- a/packages/storage-providers/src/types.ts
+++ b/packages/storage-providers/src/types.ts
@@ -67,6 +67,17 @@ export type ChangeEvent =
   | { type: 'write'; path: string }
   | { type: 'remove'; path: string };
 
+export interface BatchWrite {
+  path: string;
+  data: Uint8Array;
+  mimeType?: string;
+}
+
+export interface BatchChanges {
+  writes?: readonly BatchWrite[];
+  deletes?: readonly string[];
+}
+
 export interface StorageProvider {
   readonly metadata: ProviderMetadata;
   readonly capabilities: ProviderCapabilities;
@@ -86,6 +97,25 @@ export interface StorageProvider {
   ): Promise<void>;
 
   subscribe?(path: string, listener: (event: ChangeEvent) => void): () => void;
+
+  /**
+   * Apply several writes and deletes in one operation. Providers backed by a
+   * remote API override this to collapse the per-file round-trips into a single
+   * request; callers must fall back to per-file `write`/`remove` when it is
+   * absent.
+   */
+  applyBatch?(changes: BatchChanges, options?: WriteOptions): Promise<void>;
+
+  /**
+   * Read several files at once. Remote providers override this to fetch the
+   * bytes directly from their blob store (bypassing the API), so callers should
+   * prefer it over a loop of `read` when pulling many files. Missing paths are
+   * omitted from the returned map.
+   */
+  readMany?(
+    paths: readonly string[],
+    options?: ReadOptions,
+  ): Promise<Map<string, Uint8Array>>;
 }
 
 export interface CommitRef {

--- a/packages/sync-client/src/http-polling-provider.test.ts
+++ b/packages/sync-client/src/http-polling-provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import * as Y from 'yjs';
 
 import { HttpPollingSyncProvider } from './http-polling-provider';
@@ -71,6 +71,55 @@ describe('HttpPollingSyncProvider', () => {
     await provider.connect();
     expect(provider.status).toBe('connected');
     provider.disconnect();
+  });
+
+  it('skips the round trip on idle interval ticks and resumes after a local edit', async () => {
+    vi.useFakeTimers();
+    try {
+      let pushCalls = 0;
+      const serverDoc = new Y.Doc();
+      const transport: SyncTransport = {
+        async syncPull(_projectId, _filename, stateVector) {
+          return Y.encodeStateAsUpdate(serverDoc, stateVector);
+        },
+        async syncPush(_projectId, _filename, update, stateVector) {
+          pushCalls++;
+          if (update.byteLength > 0) {
+            Y.applyUpdate(serverDoc, update);
+          }
+          return Y.encodeStateAsUpdate(serverDoc, stateVector);
+        },
+      };
+
+      const doc = new Y.Doc();
+      const provider = new HttpPollingSyncProvider({
+        transport,
+        projectId: 'p',
+        filename: 'f.md',
+        doc,
+        intervalMs: 1000,
+      });
+      await provider.connect();
+      const afterConnect = pushCalls;
+
+      // Idle: several interval ticks elapse with no local changes.
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(pushCalls).toBe(afterConnect);
+
+      // A local edit re-arms the poll loop.
+      doc.getText('t').insert(0, 'edit');
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(pushCalls).toBe(afterConnect + 1);
+      expect(serverDoc.getText('t').toString()).toBe('edit');
+
+      // Idle again afterwards.
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(pushCalls).toBe(afterConnect + 1);
+
+      provider.disconnect();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('re-queues local changes when a push fails', async () => {

--- a/packages/sync-client/src/http-polling-provider.ts
+++ b/packages/sync-client/src/http-polling-provider.ts
@@ -49,6 +49,15 @@ export class HttpPollingSyncProvider extends BaseSyncProvider {
     this.pending.push(Y.encodeStateAsUpdate(this.doc));
     await this.sync();
     this.timer = setInterval(() => {
+      // Skip the round trip when there is nothing to push. Otherwise an open but
+      // untouched editor would poll the server forever; with one provider per
+      // entry file that is a flood of idle traffic. Local edits re-fill
+      // `pending`, and remote changes arrive via the realtime WebSocket (the
+      // primary channel) or on the next push. `sync()` stays a full round trip
+      // for explicit/forced flushes.
+      if (this.pending.length === 0) {
+        return;
+      }
       void this.sync();
     }, this.intervalMs);
   }

--- a/packages/viola/src/stores/proxies/sandbox.ts
+++ b/packages/viola/src/stores/proxies/sandbox.ts
@@ -349,14 +349,29 @@ export class Sandbox {
       recursive: true,
       ignore: [/^node_modules/, /^\.vivliostyle/],
     });
-    await Promise.all(
-      entries.map(async (entry) => {
-        if (entry.kind !== 'file') return;
-        if (entry.path === 'vivliostyle.config.json') return;
-        const bytes = await this.provider.read(entry.path);
-        newFiles[entry.path] = ref(new SandboxFile('', bytes));
-      }),
-    );
+    const paths = entries
+      .filter(
+        (entry) =>
+          entry.kind === 'file' && entry.path !== 'vivliostyle.config.json',
+      )
+      .map((entry) => entry.path);
+    // Pull all files in one shot when the provider can (remote: direct from the
+    // blob store, bypassing the API), falling back to per-file reads otherwise.
+    const bytesByPath = this.provider.readMany
+      ? await this.provider.readMany(paths)
+      : new Map(
+          await Promise.all(
+            paths.map(
+              async (path) => [path, await this.provider.read(path)] as const,
+            ),
+          ),
+        );
+    for (const path of paths) {
+      const bytes = bytesByPath.get(path);
+      if (bytes) {
+        newFiles[path] = ref(new SandboxFile('', bytes));
+      }
+    }
 
     for (const k in this.files) {
       delete this.files[k];
@@ -385,7 +400,11 @@ export class Sandbox {
     const cbor = await cli.toBinarySnapshot({ path: '/workdir' });
     const rootNode = new CborDecoder().decode(cbor) as SnapshotNode;
 
-    const traverse = async (snapshot: SnapshotNode, path = '') => {
+    // Mutate `files` synchronously so valtio batches every change into a single
+    // subscriber notification; `handleFileUpdate` then persists them in one
+    // request instead of one PUT per file. Persistence is awaited via
+    // `lastPersist` below.
+    const traverse = (snapshot: SnapshotNode, path = '') => {
       if (!snapshot) {
         return;
       }
@@ -394,14 +413,13 @@ export class Sandbox {
           {
             const [, , entries] = snapshot;
             for (const [name, entry] of Object.entries(entries)) {
-              await traverse(entry, join(path, name));
+              traverse(entry, join(path, name));
             }
             break;
           }
         case 1 /* File */:
           {
             const [, , data] = snapshot;
-            await this.provider.write(path, data);
             // FIXME: Get proper MIME type
             const mimeType =
               {
@@ -415,9 +433,10 @@ export class Sandbox {
           }
       }
     };
-    await traverse(rootNode);
-    // Wait the subscriber callback ends
+    traverse(rootNode);
+    // Let the `files` subscriber fire, then await the persistence it started.
     await new Promise((resolve) => window.requestAnimationFrame(resolve));
+    await this.lastPersist;
   }
 
   protected async saveToFileSystem(
@@ -433,6 +452,29 @@ export class Sandbox {
         // ignore missing entries (matches prior best-effort delete behavior)
       }
     }
+  }
+
+  // Tracks the latest provider persistence so a bulk operation can await the
+  // writes the `files` subscriber kicks off (see `saveMemoryToFileSystem`).
+  protected lastPersist: Promise<unknown> = Promise.resolve();
+
+  // Persist a set of changes in one shot, collapsing the per-file round-trips
+  // into a single request on providers that support batching.
+  protected async persistChanges(
+    writes: { path: string; data: Uint8Array }[],
+    deletes: string[],
+  ) {
+    if (writes.length === 0 && deletes.length === 0) {
+      return;
+    }
+    if (this.provider.applyBatch) {
+      await this.provider.applyBatch({ writes, deletes });
+      return;
+    }
+    await Promise.all([
+      ...writes.map((write) => this.saveToFileSystem(write.path, write.data)),
+      ...deletes.map((path) => this.saveToFileSystem(path, null)),
+    ]);
   }
 
   protected async handleFileUpdate(ops: INTERNAL_Op[]) {
@@ -451,14 +493,15 @@ export class Sandbox {
         updates[op[1][0]] = null;
       }
     }
-    await Promise.all([
-      (async () => {
-        const cli = await this.cli.createRemotePromise();
-        await cli.fromJSON(updates, '/workdir');
-      })(),
-      ...Object.entries(updates).map(([path, content]) =>
-        this.saveToFileSystem(path, content),
-      ),
-    ]);
+    const writes: { path: string; data: Uint8Array }[] = [];
+    const deletes: string[] = [];
+    for (const [path, content] of Object.entries(updates)) {
+      if (content) writes.push({ path, data: content });
+      else deletes.push(path);
+    }
+    const persist = this.persistChanges(writes, deletes);
+    this.lastPersist = persist;
+    const cli = await this.cli.createRemotePromise();
+    await Promise.all([cli.fromJSON(updates, '/workdir'), persist]);
   }
 }

--- a/packages/viola/src/stores/proxies/session.ts
+++ b/packages/viola/src/stores/proxies/session.ts
@@ -10,6 +10,18 @@ export type SessionStatus =
   | 'authenticated'
   | 'authenticating';
 
+// Extensions read `baseUrl` (via the session snapshot) and fetch the API from
+// their own cross-origin sandbox iframe, where a relative base (e.g. `/api`)
+// would resolve against the sandbox origin instead of the host. Anchor a
+// relative base to the host origin so `baseUrl` is always absolute; an empty
+// base is left untouched (see `DEFAULT_BASE_URL`).
+function toAbsoluteBaseUrl(baseUrl: string): string {
+  if (!baseUrl || typeof location === 'undefined') {
+    return baseUrl;
+  }
+  return new URL(baseUrl, location.origin).href.replace(/\/+$/, '');
+}
+
 // `__API_BASE_URL__` is `''` when the build was made without an API server
 // configured. The session is still constructed so the proxy stays shaped the
 // same, but we deliberately do NOT fall back to `/api` here: callers must
@@ -17,7 +29,7 @@ export type SessionStatus =
 // `'anonymous'`) so a stray auth call when cloud is disabled fails loudly
 // against an empty base URL instead of silently hitting a non-existent
 // local endpoint.
-const DEFAULT_BASE_URL = __API_BASE_URL__;
+const DEFAULT_BASE_URL = toAbsoluteBaseUrl(__API_BASE_URL__);
 const CLIENT_ID = 'vivliostyle-pub-web';
 
 function buildRedirectUri(): string {
@@ -58,8 +70,9 @@ export const session = proxy({
 });
 
 export function rebuildClients(baseUrl: string) {
-  const auth = createAuthClient(baseUrl);
-  session.baseUrl = baseUrl;
+  const absoluteBaseUrl = toAbsoluteBaseUrl(baseUrl);
+  const auth = createAuthClient(absoluteBaseUrl);
+  session.baseUrl = absoluteBaseUrl;
   session.auth = ref(auth);
-  session.api = ref(createApiClient(baseUrl, auth));
+  session.api = ref(createApiClient(absoluteBaseUrl, auth));
 }


### PR DESCRIPTION
Reworks the file API across the client, reference server, and storage providers to cut down on per-file round-trips and let large file sets be transferred more efficiently.

## File listing, hashes, and direct downloads

- File entries now carry an optional SHA-256 `hash` of their content, computed when files are written and when the directory is walked.
- `GET /projects/{id}/files?download=true` additionally returns a short-lived `downloadUrl` for each file, so clients can fetch bytes directly and bypass the API.
- A new `GET /files-download/{id}/{path}` endpoint serves the raw bytes for those URLs. It is authorized by an `exp`/`sig` query pair (an HMAC binding project, path, and expiry) instead of a bearer token, with timing-safe verification and a configurable TTL (default 5 minutes).

## Batch file writes

- A new `POST /projects/{id}/files` endpoint accepts `multipart/form-data` to create/replace many files and delete others (via `$delete` fields) in a single request, and returns the resulting entries with their hashes.

## Client and storage providers

- `ApiClient` gains `listFiles(id, { download })`, `writeFiles(id, { writes, deletes })`, and `fetchDownloadUrl(url)` (the latter deliberately sends no Authorization header, since the URL is self-authenticating).
- The remote-HTTP storage provider gains optional `applyBatch` and `readMany`; `applyBatch` falls back to per-file write/delete when a server lacks the batch endpoint, and `restore` now diffs desired files against server hashes to upload only changed/new files (deleting stale files when `clean` is set).
- The `StorageProvider` type and a `BatchWrite`/`BatchChanges` shape are extended accordingly.

## Other improvements

- The HTTP polling sync provider now skips the round-trip on idle interval ticks when nothing is pending, so an open but untouched editor no longer polls forever; local edits re-arm the loop and `sync()` still forces a full flush.
- The session store anchors a relative API base URL to the host origin, so extensions running in a cross-origin sandbox iframe always resolve an absolute `baseUrl` (an empty base is left untouched).

The OpenAPI spec/types and tests are updated to match.