### PR TITLE
fix(cli-bundle): lower unsupported syntax and polyfill Symbol.dispose for Safari

### DIFF
--- a/packages/cli-bundle/rolldown.config.ts
+++ b/packages/cli-bundle/rolldown.config.ts
@@ -459,6 +459,13 @@ const workerConfig = defineConfig({
     alias: aliasMap,
   },
   transform: {
+    // Lower syntax Safari cannot parse — @vivliostyle/cli's dist ships
+    // `using` declarations (unsupported in every Safari) and `v`-flag regex
+    // literals (Safari <17). Oxc only lowers `using` for targets es2023 and
+    // below; `es2024`/`esnext`/browser-style targets leave it untouched.
+    // Safari additionally lacks the Symbol.dispose API itself — see
+    // src/stubs/install-symbol-dispose.ts.
+    target: 'es2022',
     inject: {
       // unenv's preset injects `process` (unenv/node/process), `Buffer`
       // (node:buffer's Buffer), `setImmediate`/`clearImmediate` (node:timers),
@@ -500,6 +507,9 @@ const rolldownWorkerConfig = defineConfig({
     codeSplitting: false,
   },
   platform: 'browser',
+  transform: {
+    target: 'es2022',
+  },
   plugins: [patchEmnapiEnvDetectionPlugin],
 });
 
@@ -538,6 +548,9 @@ const clientConfig = defineConfig({
     format: 'es',
   },
   platform: 'browser',
+  transform: {
+    target: 'es2022',
+  },
   plugins: [resolveViteClientPlugin],
 });
 

--- a/packages/cli-bundle/src/index.ts
+++ b/packages/cli-bundle/src/index.ts
@@ -1,3 +1,4 @@
+import './stubs/install-symbol-dispose';
 import './stubs/install-process-global';
 import path from 'node:path';
 import type stream from 'node:stream';

--- a/packages/cli-bundle/src/stubs/install-symbol-dispose.ts
+++ b/packages/cli-bundle/src/stubs/install-symbol-dispose.ts
@@ -1,0 +1,10 @@
+// Side-effect module: Safari doesn't implement Symbol.dispose /
+// Symbol.asyncDispose. Lowering `using` syntax (transform.target in
+// rolldown.config.ts) is not enough — @vivliostyle/cli's dist keys its
+// disposables with the bare well-known symbols, and its bundled
+// __disposeResources helper throws "Symbol.dispose is not defined" when they
+// are missing. Symbol.for matches the fallback oxc's own _usingCtx helper
+// uses, so lowered `using` blocks find the same symbol.
+const symbolCtor = Symbol as { dispose?: symbol; asyncDispose?: symbol };
+symbolCtor.dispose ??= Symbol.for('Symbol.dispose');
+symbolCtor.asyncDispose ??= Symbol.for('Symbol.asyncDispose');


### PR DESCRIPTION
Fixes #63

In Safari, clicking "Create Project" hung with `Unhandled Promise Rejection: SyntaxError: Unexpected identifier '_'`. The CLI worker bundle (`/_cli/index.js`) contains twelve ES2026 `using` declarations coming from `@vivliostyle/cli`'s dist (e.g. `using _ = Logger.suspendLogging(...)`), which no Safari version can parse, so the dynamic `import('#cli-bundle')` in `cli-worker.ts` rejected before the worker could initialize. The same bundle also carries ~45 `v`-flag regex literals (parse-fatal on Safari < 17). Chrome 134+/Firefox 141+ support `using`, which is why only Safari broke.

## Changes

- **`packages/cli-bundle/rolldown.config.ts`** — set `transform.target: 'es2022'` on the worker, client, and WASI-worker bundles so `using` declarations and `v`-flag regex literals get lowered to parse-safe forms. Note that oxc only lowers `using` for targets `es2023` and below; `es2024`/`esnext`/browser-style targets leave it untouched, so the target must stay at `es2023` or lower.
- **`packages/cli-bundle/src/stubs/install-symbol-dispose.ts`** (new) — Safari also lacks the `Symbol.dispose` / `Symbol.asyncDispose` API itself. Syntax lowering alone still breaks at runtime: the CLI keys disposables with the bare well-known symbols, and its bundled `__disposeResources` helper throws `TypeError("Symbol.dispose is not defined.")` when they're missing. The shim assigns `Symbol.for('Symbol.dispose')`, matching the fallback oxc's own `_usingCtx` helper uses, and is imported first from `src/index.ts` (same pattern as `install-process-global`).

## Verification

- Rebuilt `@v/cli-bundle`; parsing `dist/index.js`, `dist/rolldown-wasi-worker.js`, and all three `dist/client/*.js` with acorn at `ecmaVersion: 2023` now succeeds (it fails on the deployed assets), proving no `using` declarations or `v`-flag literals remain.
- The polyfill assignments land at the top of the bundle, before any disposable helper can run.
- `pnpm --filter @v/cli-bundle exec vitest run src/index.test.ts` (export-shape tests) passes; `tsc --noEmit` and Biome are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMq7onHUmXeKnBSCpQAJ43