### PR TITLE
fix(viola): print from a top-level tab and close it after the dialog

### DIFF
--- a/packages/cli-bundle/src/client/viewer-adapter.ts
+++ b/packages/cli-bundle/src/client/viewer-adapter.ts
@@ -3,3 +3,18 @@ window.addEventListener('message', (event) => {
     window.print();
   }
 });
+
+// Top-level print tab flow (issue #64): the host opens the viewer in its own
+// tab with a `print` hash parameter because Firefox crashes when printing the
+// nested cross-origin isolated iframe. Wait until every page is rendered
+// (`renderAllPages` is set on the URL, so readyState only reaches 'complete'
+// once the whole book is typeset), then print.
+if (new URLSearchParams(location.hash.slice(1)).get('print') === 'true') {
+  const interval = setInterval(() => {
+    const { coreViewer } = window as { coreViewer?: { readyState?: string } };
+    if (coreViewer?.readyState === 'complete') {
+      clearInterval(interval);
+      window.print();
+    }
+  }, 250);
+}

--- a/packages/cli-bundle/src/client/viewer-adapter.ts
+++ b/packages/cli-bundle/src/client/viewer-adapter.ts
@@ -1,20 +1,19 @@
-window.addEventListener('message', (event) => {
-  if (event.data.type === 'print-pdf') {
-    window.print();
-  }
-});
-
-// Top-level print tab flow (issue #64): the host opens the viewer in its own
-// tab with a `print` hash parameter because Firefox crashes when printing the
-// nested cross-origin isolated iframe. Wait until every page is rendered
+// Print tab flow: the host opens the viewer in its own top-level tab with a
+// `print` hash parameter (printing from the nested cross-origin isolated
+// iframe crashes Firefox, issue #64). Wait until every page is rendered
 // (`renderAllPages` is set on the URL, so readyState only reaches 'complete'
-// once the whole book is typeset), then print.
+// once the whole book is typeset), then print, then close the tab —
+// window.print() blocks while the dialog is open. window.close() is allowed
+// here despite the COOP browsing-context-group swap severing the opener,
+// because the navigation replaced the initial about:blank entry and a
+// single-entry top-level context stays script-closable.
 if (new URLSearchParams(location.hash.slice(1)).get('print') === 'true') {
   const interval = setInterval(() => {
     const { coreViewer } = window as { coreViewer?: { readyState?: string } };
     if (coreViewer?.readyState === 'complete') {
       clearInterval(interval);
       window.print();
+      window.close();
     }
   }, 250);
 }

--- a/packages/cli-bundle/src/client/viewer-adapter.ts
+++ b/packages/cli-bundle/src/client/viewer-adapter.ts
@@ -1,12 +1,8 @@
-// Print tab flow: the host opens the viewer in its own top-level tab with a
-// `print` hash parameter (printing from the nested cross-origin isolated
-// iframe crashes Firefox, issue #64). Wait until every page is rendered
-// (`renderAllPages` is set on the URL, so readyState only reaches 'complete'
-// once the whole book is typeset), then print, then close the tab —
-// window.print() blocks while the dialog is open. window.close() is allowed
-// here despite the COOP browsing-context-group swap severing the opener,
-// because the navigation replaced the initial about:blank entry and a
-// single-entry top-level context stays script-closable.
+// Opened as a top-level print tab by the host (#64). readyState reaches
+// 'complete' only once every page is rendered (the URL sets renderAllPages),
+// and window.print() blocks while the dialog is open. The tab stays
+// script-closable despite the COOP swap, because the navigation replaced the
+// single about:blank history entry.
 if (new URLSearchParams(location.hash.slice(1)).get('print') === 'true') {
   const interval = setInterval(() => {
     const { coreViewer } = window as { coreViewer?: { readyState?: string } };

--- a/packages/viola-extension-preview/src/views/index.tsx
+++ b/packages/viola-extension-preview/src/views/index.tsx
@@ -1,12 +1,10 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import type { ExtensionMountContext } from '@v/extension-kit';
 
 import '@v/extension-kit/styles.css';
 
 export default function PreviewPane({ host, t }: ExtensionMountContext) {
-  const iframeRef = useRef<HTMLIFrameElement | null>(null);
-  const viewerLoadedRef = useRef(false);
   const [url, setUrl] = useState<string | null>(null);
 
   useEffect(() => {
@@ -21,47 +19,14 @@ export default function PreviewPane({ host, t }: ExtensionMountContext) {
     };
   }, [host]);
 
-  // Relays host print commands to the nested viewer, which the host can't
-  // reach itself. Only answer `print-pdf-query` once the viewer has loaded
-  // (`load` implies its message listener is in place).
-  useEffect(() => {
-    if (!url) return;
-    const viewerOrigin = new URL(url).origin;
-    const onMessage = (event: MessageEvent) => {
-      if (event.source !== window.parent) return;
-      switch (event.data?.type) {
-        case 'print-pdf-query':
-          if (viewerLoadedRef.current) {
-            window.parent.postMessage(
-              { type: 'print-pdf-ready' },
-              event.origin,
-            );
-          }
-          break;
-        case 'print-pdf':
-          iframeRef.current?.contentWindow?.postMessage(
-            { type: 'print-pdf' },
-            viewerOrigin,
-          );
-          break;
-      }
-    };
-    window.addEventListener('message', onMessage);
-    return () => window.removeEventListener('message', onMessage);
-  }, [url]);
-
   if (!url) {
     return null;
   }
 
   return (
     <iframe
-      ref={iframeRef}
       title={t('preview_iframe_title')}
       src={url}
-      onLoad={() => {
-        viewerLoadedRef.current = true;
-      }}
       className="block size-full"
       sandbox="allow-same-origin allow-scripts allow-modals"
       allow="cross-origin-isolated"

--- a/packages/viola/messages/en.json
+++ b/packages/viola/messages/en.json
@@ -48,6 +48,7 @@
   "new_project_template_blank_title": "Blank Book Template",
   "new_project_template_section_title": "Choose Template",
   "new_project_theme_label": "Theme",
+  "print_pdf_preparing": "Preparing print preview...",
   "side_menu_account_tooltip": "Account",
   "side_menu_add_new_file": "Add new file",
   "side_menu_customize_theme": "Customize theme",

--- a/packages/viola/messages/ja.json
+++ b/packages/viola/messages/ja.json
@@ -48,6 +48,7 @@
   "new_project_template_blank_title": "空の書籍テンプレート",
   "new_project_template_section_title": "テンプレートを選択",
   "new_project_theme_label": "テーマ",
+  "print_pdf_preparing": "印刷プレビューを準備しています...",
   "side_menu_account_tooltip": "アカウント",
   "side_menu_add_new_file": "ファイルを追加",
   "side_menu_customize_theme": "テーマをカスタマイズ",

--- a/packages/viola/src/stores/actions/print-pdf.tsx
+++ b/packages/viola/src/stores/actions/print-pdf.tsx
@@ -6,27 +6,19 @@ import { $cli } from '../accessors';
 let printWindow: Window | null = null;
 let printSession = 0;
 
-// Printing happens in a top-level tab rather than the nested preview pane:
-// Firefox crashes the sandbox-origin content process while generating its
-// print preview (the static document clone) for the doubly-nested
-// cross-origin isolated viewer iframe.
-// https://github.com/vivliostyle/vivliostyle.pub/issues/64
+// Printing happens in a top-level tab because Firefox crashes generating its
+// print preview for the nested cross-origin isolated viewer iframe (#64).
 export async function printPdf() {
-  // While a previous invocation is still preparing, focus its tab instead of
-  // stacking another one. A user-closed tab reports `closed`, so a hung URL
-  // resolution can never permanently disable this action. (After navigation,
-  // COOP severs the handle — which also reports `closed` — so each further
-  // click intentionally starts a fresh print tab.)
+  // A COOP-severed handle (after navigation) also reports `closed`, so each
+  // click after a successful navigation starts a fresh tab.
   if (printWindow && !printWindow.closed) {
     printWindow.focus();
     return;
   }
   const session = ++printSession;
 
-  // Open the tab synchronously so the browser attributes it to the user
-  // gesture; navigate once the viewer URL resolves. The viewer prints itself
-  // when it sees the `print` hash parameter and closes the tab when the
-  // dialog is dismissed (see cli-bundle's viewer-adapter).
+  // Open synchronously to stay within the user gesture; the viewer prints
+  // itself and closes the tab when it sees the `print` hash parameter.
   const openedWindow = window.open('about:blank', '_blank');
   invariant(openedWindow, 'Failed to open a tab for printing');
   printWindow = openedWindow;

--- a/packages/viola/src/stores/actions/print-pdf.tsx
+++ b/packages/viola/src/stores/actions/print-pdf.tsx
@@ -1,121 +1,38 @@
 import { invariant } from 'outvariant';
-import { subscribe } from 'valtio';
 
-import { extensionSandboxOrigin } from '../../extensions/sandbox-origin';
 import { m } from '../../generated/paraglide/messages';
-import { generateId } from '../../libs/generate-id';
-import { $cli, $ui } from '../accessors';
-import {
-  type ExtensionId,
-  extensionFrameKey,
-  extensionFrames,
-} from '../proxies/extension';
+import { $cli } from '../accessors';
 
-const previewExtensionId = 'preview' as ExtensionId;
-const previewPanePath = '.';
+let printing = false;
 
-// Polls `print-pdf-query` until the view answers `print-pdf-ready` (the nested
-// viewer has loaded). Polling stays correct across view reloads, unlike a
-// one-shot ready announcement.
-function waitForPrintReady(frame: HTMLIFrameElement): Promise<boolean> {
-  const targetOrigin = extensionSandboxOrigin(previewExtensionId);
-  return new Promise((resolve) => {
-    const query = () => {
-      frame.contentWindow?.postMessage(
-        { type: 'print-pdf-query' },
-        targetOrigin,
-      );
-    };
-    const finish = (ready: boolean) => {
-      clearInterval(interval);
-      clearTimeout(timer);
-      window.removeEventListener('message', onMessage);
-      resolve(ready);
-    };
-    const onMessage = (event: MessageEvent) => {
-      if (event.origin !== targetOrigin) return;
-      if (event.source !== frame.contentWindow) return;
-      if (event.data?.type !== 'print-pdf-ready') return;
-      finish(true);
-    };
-    window.addEventListener('message', onMessage);
-    const interval = setInterval(query, 250);
-    const timer = setTimeout(() => finish(false), 30_000);
-    query();
-  });
-}
-
+// Printing happens in a top-level tab rather than the nested preview pane:
 // Firefox crashes the sandbox-origin content process while generating its
-// print preview (the static document clone) for the nested cross-origin
-// isolated viewer iframe, so print from a top-level tab there instead.
+// print preview (the static document clone) for the doubly-nested
+// cross-origin isolated viewer iframe.
 // https://github.com/vivliostyle/vivliostyle.pub/issues/64
-async function printPdfInNewTab() {
-  // Open the tab synchronously so the browser attributes it to the user
-  // gesture; navigate once the viewer URL resolves. The viewer prints itself
-  // when it sees the `print` hash parameter (see cli-bundle's viewer-adapter).
-  const printWindow = window.open('about:blank', '_blank');
-  invariant(printWindow, 'Failed to open a tab for printing');
-  printWindow.document.title = m.print_pdf_preparing();
-  printWindow.document.body.textContent = m.print_pdf_preparing();
-  try {
-    const cli = await $cli.awaiter();
-    const viewerUrl = await cli.createViewerUrlPromise();
-    printWindow.location.href = `${viewerUrl}&print=true`;
-  } catch (error) {
-    printWindow.close();
-    throw error;
-  }
-}
-
 export async function printPdf() {
-  if (navigator.userAgent.includes('Firefox')) {
-    return await printPdfInNewTab();
+  if (printing) {
+    return;
   }
-
-  // Ensure the viewer pane is visible
-  if (
-    !$ui.tabs.some(
-      (tab) =>
-        tab.type === 'extension' &&
-        tab.extensionId === previewExtensionId &&
-        tab.panePath === previewPanePath,
-    )
-  ) {
-    $ui.tabs = [
-      ...$ui.tabs,
-      {
-        id: generateId(),
-        type: 'extension',
-        extensionId: previewExtensionId,
-        panePath: previewPanePath,
-      },
-    ];
+  printing = true;
+  try {
+    // Open the tab synchronously so the browser attributes it to the user
+    // gesture; navigate once the viewer URL resolves. The viewer prints
+    // itself when it sees the `print` hash parameter and closes the tab when
+    // the dialog is dismissed (see cli-bundle's viewer-adapter).
+    const printWindow = window.open('about:blank', '_blank');
+    invariant(printWindow, 'Failed to open a tab for printing');
+    printWindow.document.title = m.print_pdf_preparing();
+    printWindow.document.body.textContent = m.print_pdf_preparing();
+    try {
+      const cli = await $cli.awaiter();
+      const viewerUrl = await cli.createViewerUrlPromise();
+      printWindow.location.href = `${viewerUrl}&print=true`;
+    } catch (error) {
+      printWindow.close();
+      throw error;
+    }
+  } finally {
+    printing = false;
   }
-
-  const frameKey = extensionFrameKey(previewExtensionId, previewPanePath);
-  if (!extensionFrames[frameKey]) {
-    await new Promise<void>((resolve) => {
-      const unsubscribe = subscribe(extensionFrames, check);
-      const timer = setTimeout(finish, 10_000);
-      function finish() {
-        clearTimeout(timer);
-        unsubscribe();
-        resolve();
-      }
-      function check() {
-        if (extensionFrames[frameKey]) finish();
-      }
-      check();
-    });
-  }
-
-  const element = extensionFrames[frameKey];
-  invariant(element, 'Preview extension frame is not mounted');
-
-  const ready = await waitForPrintReady(element);
-  invariant(ready, 'Preview pane did not become ready for printing');
-  element.contentWindow?.postMessage(
-    { type: 'print-pdf' },
-    extensionSandboxOrigin(previewExtensionId),
-  );
 }

--- a/packages/viola/src/stores/actions/print-pdf.tsx
+++ b/packages/viola/src/stores/actions/print-pdf.tsx
@@ -2,8 +2,9 @@ import { invariant } from 'outvariant';
 import { subscribe } from 'valtio';
 
 import { extensionSandboxOrigin } from '../../extensions/sandbox-origin';
+import { m } from '../../generated/paraglide/messages';
 import { generateId } from '../../libs/generate-id';
-import { $ui } from '../accessors';
+import { $cli, $ui } from '../accessors';
 import {
   type ExtensionId,
   extensionFrameKey,
@@ -44,7 +45,33 @@ function waitForPrintReady(frame: HTMLIFrameElement): Promise<boolean> {
   });
 }
 
+// Firefox crashes the sandbox-origin content process while generating its
+// print preview (the static document clone) for the nested cross-origin
+// isolated viewer iframe, so print from a top-level tab there instead.
+// https://github.com/vivliostyle/vivliostyle.pub/issues/64
+async function printPdfInNewTab() {
+  // Open the tab synchronously so the browser attributes it to the user
+  // gesture; navigate once the viewer URL resolves. The viewer prints itself
+  // when it sees the `print` hash parameter (see cli-bundle's viewer-adapter).
+  const printWindow = window.open('about:blank', '_blank');
+  invariant(printWindow, 'Failed to open a tab for printing');
+  printWindow.document.title = m.print_pdf_preparing();
+  printWindow.document.body.textContent = m.print_pdf_preparing();
+  try {
+    const cli = await $cli.awaiter();
+    const viewerUrl = await cli.createViewerUrlPromise();
+    printWindow.location.href = `${viewerUrl}&print=true`;
+  } catch (error) {
+    printWindow.close();
+    throw error;
+  }
+}
+
 export async function printPdf() {
+  if (navigator.userAgent.includes('Firefox')) {
+    return await printPdfInNewTab();
+  }
+
   // Ensure the viewer pane is visible
   if (
     !$ui.tabs.some(

--- a/packages/viola/src/stores/actions/print-pdf.tsx
+++ b/packages/viola/src/stores/actions/print-pdf.tsx
@@ -3,7 +3,8 @@ import { invariant } from 'outvariant';
 import { m } from '../../generated/paraglide/messages';
 import { $cli } from '../accessors';
 
-let printing = false;
+let printWindow: Window | null = null;
+let printSession = 0;
 
 // Printing happens in a top-level tab rather than the nested preview pane:
 // Firefox crashes the sandbox-origin content process while generating its
@@ -11,28 +12,35 @@ let printing = false;
 // cross-origin isolated viewer iframe.
 // https://github.com/vivliostyle/vivliostyle.pub/issues/64
 export async function printPdf() {
-  if (printing) {
+  // While a previous invocation is still preparing, focus its tab instead of
+  // stacking another one. A user-closed tab reports `closed`, so a hung URL
+  // resolution can never permanently disable this action. (After navigation,
+  // COOP severs the handle — which also reports `closed` — so each further
+  // click intentionally starts a fresh print tab.)
+  if (printWindow && !printWindow.closed) {
+    printWindow.focus();
     return;
   }
-  printing = true;
+  const session = ++printSession;
+
+  // Open the tab synchronously so the browser attributes it to the user
+  // gesture; navigate once the viewer URL resolves. The viewer prints itself
+  // when it sees the `print` hash parameter and closes the tab when the
+  // dialog is dismissed (see cli-bundle's viewer-adapter).
+  const openedWindow = window.open('about:blank', '_blank');
+  invariant(openedWindow, 'Failed to open a tab for printing');
+  printWindow = openedWindow;
+  openedWindow.document.title = m.print_pdf_preparing();
+  openedWindow.document.body.textContent = m.print_pdf_preparing();
   try {
-    // Open the tab synchronously so the browser attributes it to the user
-    // gesture; navigate once the viewer URL resolves. The viewer prints
-    // itself when it sees the `print` hash parameter and closes the tab when
-    // the dialog is dismissed (see cli-bundle's viewer-adapter).
-    const printWindow = window.open('about:blank', '_blank');
-    invariant(printWindow, 'Failed to open a tab for printing');
-    printWindow.document.title = m.print_pdf_preparing();
-    printWindow.document.body.textContent = m.print_pdf_preparing();
-    try {
-      const cli = await $cli.awaiter();
-      const viewerUrl = await cli.createViewerUrlPromise();
-      printWindow.location.href = `${viewerUrl}&print=true`;
-    } catch (error) {
-      printWindow.close();
-      throw error;
+    const cli = await $cli.awaiter();
+    const viewerUrl = await cli.createViewerUrlPromise();
+    if (openedWindow.closed || session !== printSession) {
+      return;
     }
-  } finally {
-    printing = false;
+    openedWindow.location.href = `${viewerUrl}&print=true`;
+  } catch (error) {
+    openedWindow.close();
+    throw error;
   }
 }


### PR DESCRIPTION
Fixes #64

In Firefox, "Print PDF" hangs at "Preparing Preview" (Firefox's own print-dialog spinner) and the browser shows "Part of this page crashed." — meaning the sandbox-origin content process died. `window.print()` used to run inside the Vivliostyle viewer iframe, which is a doubly-nested, cross-origin (out-of-process), sandboxed, crossOriginIsolated (COOP+COEP), service-worker-controlled frame whose process also hosts the CLI worker and its ≥1 GiB shared WASM memory. Firefox's subframe print-preview machinery (static document clone + CrossProcessPaint) has a documented history of OOP-iframe failures (e.g. [Bug 1676188](https://bugzilla.mozilla.org/show_bug.cgi?id=1676188), [Bug 1695806](https://bugzilla.mozilla.org/show_bug.cgi?id=1695806), [Bug 1725572](https://bugzilla.mozilla.org/show_bug.cgi?id=1725572)), and nothing appears to exercise this COOP/COEP+SW combination — printing dies mid-clone.

## Changes

"Print PDF" now prints from a **top-level tab** in **every browser** (no UA gating), and the tab closes itself once the print dialog is dismissed:

- **`packages/viola/src/stores/actions/print-pdf.tsx`** — `printPdf()` opens `about:blank` synchronously (so the tab is attributed to the user gesture), shows a localized "Preparing print preview..." placeholder, then navigates to the viewer URL (`cli.createViewerUrlPromise()`) with an extra `&print=true` hash parameter. The sandbox-origin service worker already serves top-level navigations to `/__vivliostyle-viewer/` (see `sw-iframe.ts` `handleNavigate`), and the BroadcastChannel to the CLI worker is origin-scoped, so the viewer works in a fresh tab. Re-clicking while a previous tab is still preparing focuses it instead of stacking tabs; a closed (or COOP-severed) handle starts a fresh attempt, so a hung URL resolution can never permanently disable the action, and a session counter keeps a stale resolution from navigating a superseded tab.
- **`packages/cli-bundle/src/client/viewer-adapter.ts`** — when the `print` hash parameter is present, poll until `window.coreViewer.readyState === 'complete'` (with `renderAllPages=true` this means the whole book is typeset — the same signal `@vivliostyle/cli` awaits before building PDFs), call `window.print()`, then `window.close()`. `window.print()` blocks while the dialog is open, so the tab closes exactly when the user dismisses the dialog (printed or cancelled) and they land back on the editor. `window.close()` works despite the COOP browsing-context-group swap severing the opener, because the viewer navigation replaced the initial `about:blank` history entry and a single-entry top-level context stays script-closable.
- **In-pane print machinery removed** — with every browser on the tab flow there is no caller left for the `print-pdf-query`/`print-pdf-ready`/`print-pdf` postMessage relay, so the preview extension view (`packages/viola-extension-preview/src/views/index.tsx`) drops its relay/`onLoad` tracking and the viewer adapter drops its message listener. This also removes the blank-page failure mode of the old in-pane flow (readiness was keyed to iframe `load`, long before pages rendered — issue #65): the tab flow always waits for the full render, and no editor+preview split layout is created in the first place.

## Behavior after the fix

1. "Print PDF" opens a new tab showing "Preparing print preview...", which navigates to the viewer and visibly renders pages.
2. The print dialog appears once all pages are typeset, showing the full book.
3. Closing the dialog (print or cancel) closes the tab, returning to the editor exactly as it was.
4. Clicking "Print PDF" again while a tab is still preparing focuses that tab; after closing a tab, clicking again starts a fresh one.

## Verification

- Verified end-to-end in Chrome against the local dev server: the tab opens on click, renders all pages, and the print dialog appears (the viewer tab's main thread blocks on the open dialog, confirming `window.print()` fired after `readyState === 'complete'`); closing the tab and re-clicking opens a fresh tab.
- `pnpm typecheck` (all 18 tasks), `pnpm --filter @v/cli-bundle build` + its export-shape tests, and Biome pass; no references to the removed print messages remain.
- Manual check still needed in Firefox (no crash bar) and Safari (needs #66 to get past project creation).

> [\!IMPORTANT]
> **Testing this on the PR-preview deployment requires #69.** Preview deployments currently produce per-project sandbox subdomains that exceed the 63-character DNS label limit (`sandbox-<25-char projectId>--pr-preview-67-vivliostyle-pub` is 64 chars), so the project sandbox never resolves, the CLI worker never boots, and the print tab sits at "Preparing print preview..." forever — which also made earlier revisions of this flow appear to "not open a tab" once the stuck guard swallowed further clicks. That deadlock is fixed here, and the underlying DNS issue is fixed in #69.

Note for #68 (issue #65): this PR supersedes its in-pane readiness handshake — with the tab flow, blank-page printing and the stuck split layout can no longer occur. The part of #68 still relevant on its own is the "Open Print Preview" route change that makes it a reliable escape from any pre-existing split layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMq7onHUmXeKnBSCpQAJ43