### PR TITLE
fix(viola): print only after every page renders, then restore the layout

### DIFF
--- a/packages/cli-bundle/src/client/viewer-adapter.ts
+++ b/packages/cli-bundle/src/client/viewer-adapter.ts
@@ -1,5 +1,23 @@
 window.addEventListener('message', (event) => {
-  if (event.data.type === 'print-pdf') {
-    window.print();
+  const source = event.source as Window | null;
+  switch (event.data?.type) {
+    case 'print-pdf-query': {
+      // Only answer once every page is rendered — the viewer URL sets
+      // renderAllPages, so readyState reaches 'complete' when the whole book
+      // is typeset. Answering earlier makes the print dialog capture blank
+      // pages. Unanswered queries are fine: the host keeps polling.
+      const { coreViewer } = window as { coreViewer?: { readyState?: string } };
+      if (coreViewer?.readyState === 'complete') {
+        source?.postMessage({ type: 'print-pdf-ready' }, event.origin);
+      }
+      break;
+    }
+    case 'print-pdf': {
+      // window.print() blocks until the print dialog closes, so `done` also
+      // tells the host it's safe to restore the pane layout.
+      window.print();
+      source?.postMessage({ type: 'print-pdf-done' }, event.origin);
+      break;
+    }
   }
 });

--- a/packages/cli-bundle/src/client/viewer-adapter.ts
+++ b/packages/cli-bundle/src/client/viewer-adapter.ts
@@ -2,10 +2,8 @@ window.addEventListener('message', (event) => {
   const source = event.source as Window | null;
   switch (event.data?.type) {
     case 'print-pdf-query': {
-      // Only answer once every page is rendered — the viewer URL sets
-      // renderAllPages, so readyState reaches 'complete' when the whole book
-      // is typeset. Answering earlier makes the print dialog capture blank
-      // pages. Unanswered queries are fine: the host keeps polling.
+      // readyState reaches 'complete' once every page is rendered (the URL
+      // sets renderAllPages); answering earlier would print blank pages.
       const { coreViewer } = window as { coreViewer?: { readyState?: string } };
       if (coreViewer?.readyState === 'complete') {
         source?.postMessage({ type: 'print-pdf-ready' }, event.origin);
@@ -13,8 +11,7 @@ window.addEventListener('message', (event) => {
       break;
     }
     case 'print-pdf': {
-      // window.print() blocks until the print dialog closes, so `done` also
-      // tells the host it's safe to restore the pane layout.
+      // window.print() blocks until the print dialog closes.
       window.print();
       source?.postMessage({ type: 'print-pdf-done' }, event.origin);
       break;

--- a/packages/viola-extension-preview/src/views/index.tsx
+++ b/packages/viola-extension-preview/src/views/index.tsx
@@ -6,7 +6,7 @@ import '@v/extension-kit/styles.css';
 
 export default function PreviewPane({ host, t }: ExtensionMountContext) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
-  const viewerLoadedRef = useRef(false);
+  const hostOriginRef = useRef<string | null>(null);
   const [url, setUrl] = useState<string | null>(null);
 
   useEffect(() => {
@@ -21,29 +21,37 @@ export default function PreviewPane({ host, t }: ExtensionMountContext) {
     };
   }, [host]);
 
-  // Relays host print commands to the nested viewer, which the host can't
-  // reach itself. Only answer `print-pdf-query` once the viewer has loaded
-  // (`load` implies its message listener is in place).
+  // Relays print messages between the host and the nested viewer, which can't
+  // reach each other directly. Readiness is answered by the viewer itself
+  // (cli-bundle's viewer-adapter), the only party that knows when every page
+  // has rendered.
   useEffect(() => {
     if (!url) return;
     const viewerOrigin = new URL(url).origin;
     const onMessage = (event: MessageEvent) => {
-      if (event.source !== window.parent) return;
-      switch (event.data?.type) {
-        case 'print-pdf-query':
-          if (viewerLoadedRef.current) {
-            window.parent.postMessage(
-              { type: 'print-pdf-ready' },
-              event.origin,
+      if (event.source === window.parent) {
+        switch (event.data?.type) {
+          case 'print-pdf-query':
+          case 'print-pdf':
+            hostOriginRef.current = event.origin;
+            iframeRef.current?.contentWindow?.postMessage(
+              event.data,
+              viewerOrigin,
             );
-          }
-          break;
-        case 'print-pdf':
-          iframeRef.current?.contentWindow?.postMessage(
-            { type: 'print-pdf' },
-            viewerOrigin,
-          );
-          break;
+            break;
+        }
+      } else if (
+        event.source === iframeRef.current?.contentWindow &&
+        event.origin === viewerOrigin
+      ) {
+        switch (event.data?.type) {
+          case 'print-pdf-ready':
+          case 'print-pdf-done':
+            if (hostOriginRef.current) {
+              window.parent.postMessage(event.data, hostOriginRef.current);
+            }
+            break;
+        }
       }
     };
     window.addEventListener('message', onMessage);
@@ -59,9 +67,6 @@ export default function PreviewPane({ host, t }: ExtensionMountContext) {
       ref={iframeRef}
       title={t('preview_iframe_title')}
       src={url}
-      onLoad={() => {
-        viewerLoadedRef.current = true;
-      }}
       className="block size-full"
       sandbox="allow-same-origin allow-scripts allow-modals"
       allow="cross-origin-isolated"

--- a/packages/viola-extension-preview/src/views/index.tsx
+++ b/packages/viola-extension-preview/src/views/index.tsx
@@ -21,10 +21,8 @@ export default function PreviewPane({ host, t }: ExtensionMountContext) {
     };
   }, [host]);
 
-  // Relays print messages between the host and the nested viewer, which can't
-  // reach each other directly. Readiness is answered by the viewer itself
-  // (cli-bundle's viewer-adapter), the only party that knows when every page
-  // has rendered.
+  // Relays print messages between the host and the nested viewer, which
+  // can't reach each other directly.
   useEffect(() => {
     if (!url) return;
     const viewerOrigin = new URL(url).origin;

--- a/packages/viola/src/routes/(main)/_layout/projects/$projectId/preview.tsx
+++ b/packages/viola/src/routes/(main)/_layout/projects/$projectId/preview.tsx
@@ -19,9 +19,8 @@ export const Route = createFileRoute(
     } catch {
       throw redirect({ to: '/' });
     }
-    // Reuse an existing preview tab (keeping its id so the viewer iframe
-    // doesn't remount) while still trimming any other panes, so this route is
-    // a reliable escape from a split layout.
+    // Keep an existing preview tab's id so the viewer iframe doesn't remount
+    // when trimming other panes away.
     const existingTab = $ui.tabs.find(
       (tab) => tab.type === 'extension' && tab.extensionId === 'preview',
     );

--- a/packages/viola/src/routes/(main)/_layout/projects/$projectId/preview.tsx
+++ b/packages/viola/src/routes/(main)/_layout/projects/$projectId/preview.tsx
@@ -19,15 +19,17 @@ export const Route = createFileRoute(
     } catch {
       throw redirect({ to: '/' });
     }
-    if (
-      $ui.tabs.some(
-        (tab) => tab.type === 'extension' && tab.extensionId === 'preview',
-      )
-    ) {
+    // Reuse an existing preview tab (keeping its id so the viewer iframe
+    // doesn't remount) while still trimming any other panes, so this route is
+    // a reliable escape from a split layout.
+    const existingTab = $ui.tabs.find(
+      (tab) => tab.type === 'extension' && tab.extensionId === 'preview',
+    );
+    if (existingTab && $ui.tabs.length === 1) {
       return;
     }
     $ui.tabs = [
-      {
+      existingTab ?? {
         id: generateId(),
         type: 'extension',
         extensionId: 'preview' as ExtensionId,

--- a/packages/viola/src/stores/actions/print-pdf.tsx
+++ b/packages/viola/src/stores/actions/print-pdf.tsx
@@ -15,10 +15,8 @@ const previewExtensionId = 'preview' as ExtensionId;
 const previewPanePath = '.';
 
 // Polls `print-pdf-query` until the viewer answers `print-pdf-ready` (every
-// page is rendered). Polling stays correct across view reloads, unlike a
-// one-shot ready announcement. The timeout must accommodate a full book
-// render from a cold start; the preview pane doubles as the progress
-// indication while the user waits.
+// page is rendered); polling stays correct across view reloads. The timeout
+// must accommodate a full book render from a cold start.
 function waitForPrintReady(frame: HTMLIFrameElement): Promise<boolean> {
   const targetOrigin = extensionSandboxOrigin(previewExtensionId);
   return new Promise((resolve) => {
@@ -62,8 +60,6 @@ function waitForPrintDone(frame: HTMLIFrameElement): Promise<boolean> {
       finish(true);
     };
     window.addEventListener('message', onMessage);
-    // The dialog can stay open indefinitely; on timeout just leave the pane
-    // in place instead of yanking it out from under a live print preview.
     const timer = setTimeout(() => finish(false), 600_000);
   });
 }
@@ -133,9 +129,8 @@ async function printPdfViaPreviewPane() {
     extensionSandboxOrigin(previewExtensionId),
   );
 
-  // If this action opened the pane, restore the previous layout — but only
-  // after the dialog closes, since the print preview is fed live from the
-  // pane's iframe.
+  // Restore the layout only after the dialog closes — the print preview is
+  // fed live from the pane's iframe.
   if (addedTabId && (await printDone)) {
     $ui.tabs = $ui.tabs.filter((tab) => tab.id !== addedTabId);
   }

--- a/packages/viola/src/stores/actions/print-pdf.tsx
+++ b/packages/viola/src/stores/actions/print-pdf.tsx
@@ -9,13 +9,16 @@ import {
   extensionFrameKey,
   extensionFrames,
 } from '../proxies/extension';
+import type { PaneId } from '../proxies/ui';
 
 const previewExtensionId = 'preview' as ExtensionId;
 const previewPanePath = '.';
 
-// Polls `print-pdf-query` until the view answers `print-pdf-ready` (the nested
-// viewer has loaded). Polling stays correct across view reloads, unlike a
-// one-shot ready announcement.
+// Polls `print-pdf-query` until the viewer answers `print-pdf-ready` (every
+// page is rendered). Polling stays correct across view reloads, unlike a
+// one-shot ready announcement. The timeout must accommodate a full book
+// render from a cold start; the preview pane doubles as the progress
+// indication while the user waits.
 function waitForPrintReady(frame: HTMLIFrameElement): Promise<boolean> {
   const targetOrigin = extensionSandboxOrigin(previewExtensionId);
   return new Promise((resolve) => {
@@ -39,13 +42,49 @@ function waitForPrintReady(frame: HTMLIFrameElement): Promise<boolean> {
     };
     window.addEventListener('message', onMessage);
     const interval = setInterval(query, 250);
-    const timer = setTimeout(() => finish(false), 30_000);
+    const timer = setTimeout(() => finish(false), 300_000);
     query();
   });
 }
 
+function waitForPrintDone(frame: HTMLIFrameElement): Promise<boolean> {
+  const targetOrigin = extensionSandboxOrigin(previewExtensionId);
+  return new Promise((resolve) => {
+    const finish = (done: boolean) => {
+      clearTimeout(timer);
+      window.removeEventListener('message', onMessage);
+      resolve(done);
+    };
+    const onMessage = (event: MessageEvent) => {
+      if (event.origin !== targetOrigin) return;
+      if (event.source !== frame.contentWindow) return;
+      if (event.data?.type !== 'print-pdf-done') return;
+      finish(true);
+    };
+    window.addEventListener('message', onMessage);
+    // The dialog can stay open indefinitely; on timeout just leave the pane
+    // in place instead of yanking it out from under a live print preview.
+    const timer = setTimeout(() => finish(false), 600_000);
+  });
+}
+
+let printing = false;
+
 export async function printPdf() {
+  if (printing) {
+    return;
+  }
+  printing = true;
+  try {
+    await printPdfViaPreviewPane();
+  } finally {
+    printing = false;
+  }
+}
+
+async function printPdfViaPreviewPane() {
   // Ensure the viewer pane is visible
+  let addedTabId: PaneId | undefined;
   if (
     !$ui.tabs.some(
       (tab) =>
@@ -54,10 +93,11 @@ export async function printPdf() {
         tab.panePath === previewPanePath,
     )
   ) {
+    addedTabId = generateId();
     $ui.tabs = [
       ...$ui.tabs,
       {
-        id: generateId(),
+        id: addedTabId,
         type: 'extension',
         extensionId: previewExtensionId,
         panePath: previewPanePath,
@@ -87,8 +127,16 @@ export async function printPdf() {
 
   const ready = await waitForPrintReady(element);
   invariant(ready, 'Preview pane did not become ready for printing');
+  const printDone = waitForPrintDone(element);
   element.contentWindow?.postMessage(
     { type: 'print-pdf' },
     extensionSandboxOrigin(previewExtensionId),
   );
+
+  // If this action opened the pane, restore the previous layout — but only
+  // after the dialog closes, since the print preview is fed live from the
+  // pane's iframe.
+  if (addedTabId && (await printDone)) {
+    $ui.tabs = $ui.tabs.filter((tab) => tab.id !== addedTabId);
+  }
 }


### PR DESCRIPTION
Fixes #65

With the preview pane closed, "Print PDF" opened the browser's print dialog over a viewer that hadn't rendered a single page yet, producing a blank document. The readiness handshake (`print-pdf-query` → `print-pdf-ready`) was answered by the preview extension view as soon as the nested viewer iframe fired `load` — but `load` only means the viewer's HTML booted; Vivliostyle typesets pages asynchronously long after that. It also left the editor+preview split open with no way back (both the edit and preview routes early-return when their tab already exists, and panes have no close control).

## Changes

- **`packages/cli-bundle/src/client/viewer-adapter.ts`** — the viewer window itself now answers `print-pdf-query`, and only once `window.coreViewer.readyState === 'complete'`; with `renderAllPages=true` on the viewer URL that means the whole book is typeset (the same signal `@vivliostyle/cli` awaits before building PDFs). Unanswered queries are safe because the host polls. After `window.print()` returns (it blocks until the dialog closes), the adapter posts `print-pdf-done`.
- **`packages/viola-extension-preview/src/views/index.tsx`** — the extension view becomes a pure relay: it forwards `print-pdf-query` / `print-pdf` into the nested viewer and `print-pdf-ready` / `print-pdf-done` back to the host, instead of answering readiness from its own `load` flag (`viewerLoadedRef` / `onLoad` are gone).
- **`packages/viola/src/stores/actions/print-pdf.tsx`** — `printPdf` remembers when it opened the preview tab itself and removes it again after `print-pdf-done`, restoring the pre-print layout (on timeout the pane is left alone rather than yanked out from under a live print preview). The readiness timeout grows from 30 s to 5 min — a real book render from a cold start can easily exceed 30 s, and the visibly-rendering pane doubles as progress indication. A re-entrancy guard prevents double-clicks from queueing a second dialog.
- **`packages/viola/src/routes/(main)/_layout/projects/$projectId/preview.tsx`** — "Open Print Preview" now trims other panes while reusing an existing preview tab (same id, so the viewer doesn't remount) instead of early-returning, making it a reliable escape from any split layout.

## Behavior after the fix

1. "Print PDF" from the editor opens the preview pane, which visibly renders pages; the print dialog appears only when rendering completes, showing typeset pages.
2. Closing the dialog returns to the editor-only layout.
3. With the preview already rendered, "Print PDF" opens the dialog near-instantly and leaves the layout untouched.

## Verification

`pnpm typecheck` (all 18 tasks), `pnpm --filter @v/cli-bundle build`, and Biome pass. The dialog interaction itself needs a manual check (print dialogs can't be automated): steps 1–3 above in Chrome, plus the regression check that "Open Print Preview" still shows a full-screen preview, including from a split state.

Related: #67 makes Firefox print from a top-level tab (issue #64); both PRs touch `viewer-adapter.ts` / `print-pdf.tsx`, so whichever lands second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMq7onHUmXeKnBSCpQAJ43