### PR TITLE
fix(deploy): keep preview sandbox subdomains within the DNS label limit

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -42,7 +42,10 @@ jobs:
             echo "preview=true" >> $GITHUB_OUTPUT
             echo "preview-alias=pr-preview-${{ github.event.number }}" >> $GITHUB_OUTPUT
             echo "hostname=pr-preview-${{ github.event.number }}-vivliostyle-pub-app.vivliostyle.workers.dev" >> $GITHUB_OUTPUT
-            echo "sandbox-identifier=pr-preview-${{ github.event.number }}-vivliostyle-pub" >> $GITHUB_OUTPUT
+            # Sandbox subdomain labels are `sandbox-<25-char projectId>--<identifier>`
+            # and must stay within the 63-character DNS label limit, so the
+            # identifier can be at most 28 characters.
+            echo "sandbox-identifier=pr-${{ github.event.number }}-vivliostyle-pub" >> $GITHUB_OUTPUT
           fi
       - run: pnpm build
         env:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -42,9 +42,8 @@ jobs:
             echo "preview=true" >> $GITHUB_OUTPUT
             echo "preview-alias=pr-preview-${{ github.event.number }}" >> $GITHUB_OUTPUT
             echo "hostname=pr-preview-${{ github.event.number }}-vivliostyle-pub-app.vivliostyle.workers.dev" >> $GITHUB_OUTPUT
-            # Sandbox subdomain labels are `sandbox-<25-char projectId>--<identifier>`
-            # and must stay within the 63-character DNS label limit, so the
-            # identifier can be at most 28 characters.
+            # `sandbox-<25-char projectId>--<identifier>` must fit the 63-char
+            # DNS label limit, so keep the identifier within 28 characters.
             echo "sandbox-identifier=pr-${{ github.event.number }}-vivliostyle-pub" >> $GITHUB_OUTPUT
           fi
       - run: pnpm build

--- a/packages/viola/src/libs/origins.ts
+++ b/packages/viola/src/libs/origins.ts
@@ -27,6 +27,15 @@ function sandboxSubdomainIdentifier(): string {
 // `sandbox-<projectId>` or `sandbox-ext-<extensionId>`.
 export function sandboxOrigin(label: string): string {
   const url = new URL(sandboxBaseOrigin());
-  url.hostname = `${label}${sandboxSubdomainIdentifier()}.${url.hostname}`;
+  const subdomain = `${label}${sandboxSubdomainIdentifier()}`;
+  // DNS caps each hostname label at 63 characters; an oversized subdomain
+  // fails with an unhelpful NAME_NOT_RESOLVED long after this call, so make
+  // the misconfiguration diagnosable at the source.
+  if (subdomain.length > 63) {
+    console.error(
+      `Sandbox subdomain "${subdomain}" exceeds the 63-character DNS label limit and will not resolve`,
+    );
+  }
+  url.hostname = `${subdomain}.${url.hostname}`;
   return url.origin;
 }

--- a/packages/viola/src/libs/origins.ts
+++ b/packages/viola/src/libs/origins.ts
@@ -28,9 +28,6 @@ function sandboxSubdomainIdentifier(): string {
 export function sandboxOrigin(label: string): string {
   const url = new URL(sandboxBaseOrigin());
   const subdomain = `${label}${sandboxSubdomainIdentifier()}`;
-  // DNS caps each hostname label at 63 characters; an oversized subdomain
-  // fails with an unhelpful NAME_NOT_RESOLVED long after this call, so make
-  // the misconfiguration diagnosable at the source.
   if (subdomain.length > 63) {
     console.error(
       `Sandbox subdomain "${subdomain}" exceeds the 63-character DNS label limit and will not resolve`,


### PR DESCRIPTION
On PR-preview deployments, per-project sandbox subdomains have been silently broken since the sandbox identifier was introduced (#60): the label `sandbox-<25-char projectId>--pr-preview-<n>-vivliostyle-pub` is **64 characters — one over the 63-character DNS label limit** — so the hostname is not even a legal DNS name (`dig` rejects it with "label too long", browsers show `ERR_NAME_NOT_RESOLVED`).

As a result, on every preview deployment the per-project sandbox iframe never loads, the CLI worker never boots, and everything behind it (preview pane, Print PDF, EPUB/WebPub exports) hangs with no visible error. Project *creation* kept working because the draft sandbox label (`sandbox-draft--pr-preview-<n>-vivliostyle-pub`, 44 chars) is legal, which made the breakage look like a per-feature bug rather than an environment one — this is exactly what made the Print PDF tab on the #67 preview appear to "do nothing" (see #67 discussion). Alpha is unaffected: `sandbox-<projectId>--alpha-vivliostyle-pub` is 56 characters.

## Changes

- **`.github/workflows/build-deploy.yml`** — shorten the preview sandbox identifier from `pr-preview-<n>-vivliostyle-pub` to `pr-<n>-vivliostyle-pub`, keeping the `-vivliostyle-pub` namespace on the shared `vspub.dev` base host. The full label becomes 56 characters (same headroom as alpha) and stays legal up to 7-digit PR numbers. A comment documents the 28-character identifier budget.
- **`packages/viola/src/libs/origins.ts`** — `sandboxOrigin()` now logs an explicit `console.error` when a computed subdomain exceeds 63 characters, so a future overflow is diagnosable at the source instead of surfacing as an unexplained `NAME_NOT_RESOLVED` far downstream.

## Verification

- `dig 'sandbox-3bxe38pxcq9mtfh6o6tn82k0h--pr-preview-67-vivliostyle-pub.vspub.dev'` → rejected, "label too long" (64 chars); the same label with `pr-67-vivliostyle-pub` is 56 chars and well-formed.
- Reproduced end-to-end on the #67 preview in Chrome: the draft sandbox loads (project creation works) while the project sandbox request fails with `ERR_NAME_NOT_RESOLVED`.
- `pnpm --filter @v/viola typecheck` and Biome pass. The `sw.ts` hostname branch (`startsWith('sandbox-')`) and the Cloudflare worker are identifier-agnostic, so no other changes are needed.
- After merging, PR previews created/rebased from main will get working project sandboxes; this PR's own preview can be used to confirm (create a project → the preview pane should render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMq7onHUmXeKnBSCpQAJ43