### PR TITLE
docs: trim redundant comments from the Safari syntax fix

### DIFF
--- a/packages/cli-bundle/rolldown.config.ts
+++ b/packages/cli-bundle/rolldown.config.ts
@@ -459,12 +459,10 @@ const workerConfig = defineConfig({
     alias: aliasMap,
   },
   transform: {
-    // Lower syntax Safari cannot parse — @vivliostyle/cli's dist ships
-    // `using` declarations (unsupported in every Safari) and `v`-flag regex
-    // literals (Safari <17). Oxc only lowers `using` for targets es2023 and
-    // below; `es2024`/`esnext`/browser-style targets leave it untouched.
-    // Safari additionally lacks the Symbol.dispose API itself — see
-    // src/stubs/install-symbol-dispose.ts.
+    // Lower the `using` declarations and v-flag regexes in @vivliostyle/cli's
+    // dist, which Safari cannot parse. Oxc lowers `using` only for es2023 and
+    // below — es2024/esnext/browser-style targets leave it untouched. The
+    // Symbol.dispose API gap is covered by src/stubs/install-symbol-dispose.ts.
     target: 'es2022',
     inject: {
       // unenv's preset injects `process` (unenv/node/process), `Buffer`

--- a/packages/cli-bundle/src/stubs/install-symbol-dispose.ts
+++ b/packages/cli-bundle/src/stubs/install-symbol-dispose.ts
@@ -1,10 +1,8 @@
-// Side-effect module: Safari doesn't implement Symbol.dispose /
-// Symbol.asyncDispose. Lowering `using` syntax (transform.target in
-// rolldown.config.ts) is not enough — @vivliostyle/cli's dist keys its
-// disposables with the bare well-known symbols, and its bundled
-// __disposeResources helper throws "Symbol.dispose is not defined" when they
-// are missing. Symbol.for matches the fallback oxc's own _usingCtx helper
-// uses, so lowered `using` blocks find the same symbol.
+// Safari lacks Symbol.dispose/asyncDispose, and lowering `using` syntax
+// (transform.target in rolldown.config.ts) is not enough: @vivliostyle/cli
+// keys its disposables with the bare well-known symbols and its bundled
+// __disposeResources helper throws when they're missing. Symbol.for matches
+// the fallback in oxc's own _usingCtx helper.
 const symbolCtor = Symbol as { dispose?: symbol; asyncDispose?: symbol };
 symbolCtor.dispose ??= Symbol.for('Symbol.dispose');
 symbolCtor.asyncDispose ??= Symbol.for('Symbol.asyncDispose');


### PR DESCRIPTION
Follow-up to #66 (already merged): condenses the comments added there to the essentials — the oxc `using`-lowering target gotcha and the cross-reference between `transform.target` and the `Symbol.dispose` stub. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMq7onHUmXeKnBSCpQAJ43