### PR TITLE
fix: browser-specific breakage on deployed environments (Safari OPFS corruption, print-tab partition, export/server readiness, new-project required fields)

### DIFF
--- a/packages/cli-bundle/rolldown.config.ts
+++ b/packages/cli-bundle/rolldown.config.ts
@@ -362,6 +362,32 @@ const patchRolldownBindingPlugin: Plugin = {
   },
 };
 
+// `@bluwy/giget-core` writes the downloaded template tarball with
+// `pipeline(response.body, fss.createWriteStream(...))`. Piping a web
+// ReadableStream through the readable-stream polyfill breaks on Safari, and
+// giget swallows the failure whenever the (already-created, empty) file
+// exists, so node-tar later dies with `TAR_BAD_ARCHIVE: Unrecognized archive
+// format`. Buffer the body and write it in one shot instead — templates are
+// a few kilobytes, streaming buys nothing inside the worker's memfs.
+const patchGigetDownloadPlugin: Plugin = {
+  name: 'patch-giget-download',
+  transform: {
+    filter: { id: /[\\/]@bluwy[\\/]giget-core[\\/]src[\\/]utils\.js$/ },
+    handler(code) {
+      const patched = code.replace(
+        /const stream = fss\.createWriteStream\(filePath\)\s*\n\s*await promisify\(pipeline\)\(response\.body, stream\)/,
+        'fss.writeFileSync(filePath, new Uint8Array(await response.arrayBuffer()))',
+      );
+      if (patched === code) {
+        throw new Error(
+          'patch-giget-download: target code not found in giget-core utils.js',
+        );
+      }
+      return patched;
+    },
+  },
+};
+
 // `parse-entities@2`'s package.json ships a `browser` field that swaps
 // `./decode-entity.js` (a static lookup table) for `./decode-entity.browser.js`,
 // which decodes via `document.createElement('i').innerHTML = '&...;'`. With
@@ -491,6 +517,7 @@ const workerConfig = defineConfig({
     // rewrites the same expression into a virtual file:// URL.
     patchRolldownBindingPlugin,
     patchEmnapiEnvDetectionPlugin,
+    patchGigetDownloadPlugin,
     redirectRolldownToBrowserPlugin,
     resolveImportMetaPlugin,
     undoParseEntitiesBrowserPlugin,

--- a/packages/cli-bundle/src/index.ts
+++ b/packages/cli-bundle/src/index.ts
@@ -40,8 +40,19 @@ function sendHotPayload(payload: HotPayload) {
 }
 
 let server: ViteDevServer | undefined;
+let setupServerPromise: Promise<void> | undefined;
 
-export async function setupServer() {
+// Memoized: callers race (preview pane, print tab, EPUB/WebPub exports), and a
+// second createServer would orphan the first instance's middleware stack.
+export function setupServer() {
+  setupServerPromise ??= doSetupServer().catch((error) => {
+    setupServerPromise = undefined;
+    throw error;
+  });
+  return setupServerPromise;
+}
+
+async function doSetupServer() {
   // The @rolldown/browser WASI binding finishes its top-level await
   // (`init_rolldown_binding_wasi_browser`) when the napi instance exists,
   // but the WASI Worker (`/_cli/rolldown-wasi-worker.js`) is spawned
@@ -78,6 +89,7 @@ export async function setupServer() {
 }
 
 export async function teardownServer() {
+  setupServerPromise = undefined;
   await server?.close();
   server = undefined;
 }
@@ -186,9 +198,7 @@ export async function serve(
 }
 
 export async function buildEpub() {
-  if (!server) {
-    throw new Error('Server is not ready');
-  }
+  await setupServer();
   await vivliostyleBuild({
     cwd: '/workdir',
     logLevel: 'info',
@@ -199,9 +209,7 @@ export async function buildEpub() {
 }
 
 export async function buildWebPub() {
-  if (!server) {
-    throw new Error('Server is not ready');
-  }
+  await setupServer();
   await vivliostyleBuild({
     cwd: '/workdir',
     logLevel: 'info',

--- a/packages/storage-providers/src/providers/opfs.test.ts
+++ b/packages/storage-providers/src/providers/opfs.test.ts
@@ -37,10 +37,13 @@ class MockFileSystemFileHandle {
     } as unknown as File;
   }
 
+  lastWrittenChunk: Blob | Uint8Array | string | null = null;
+
   async createWritable() {
     let buffered: Uint8Array | null = null;
     return {
       write: async (chunk: Blob | Uint8Array | string) => {
+        this.lastWrittenChunk = chunk;
         if (chunk instanceof Blob) {
           buffered = new Uint8Array(await chunk.arrayBuffer());
         } else if (chunk instanceof Uint8Array) {
@@ -194,6 +197,23 @@ describe('OPFSStorageProvider', () => {
       await provider.write('mut.txt', encode('first'));
       await provider.write('mut.txt', encode('second'));
       expect(decode(await provider.read('mut.txt'))).toBe('second');
+    });
+
+    // WebKit's FileSystemWritableFileStream.write() ignores a view's
+    // byteOffset/byteLength and writes the entire underlying ArrayBuffer.
+    it('never passes a partial view to createWritable', async () => {
+      const root = new MockFileSystemDirectoryHandle();
+      const p = new OPFSStorageProvider(
+        root as unknown as FileSystemDirectoryHandle,
+      );
+      const backing = new Uint8Array(64).fill(0x41);
+      const view = backing.subarray(8, 16).fill(0x42);
+      await p.write('view.bin', view);
+      const handle = root.children.get('view.bin') as MockFileSystemFileHandle;
+      const chunk = handle.lastWrittenChunk as Uint8Array;
+      expect(chunk.byteOffset).toBe(0);
+      expect(chunk.byteLength).toBe(chunk.buffer.byteLength);
+      expect(decode(await p.read('view.bin'))).toBe('BBBBBBBB');
     });
 
     it('throws StorageNotFoundError when reading a missing file', async () => {

--- a/packages/storage-providers/src/providers/opfs.ts
+++ b/packages/storage-providers/src/providers/opfs.ts
@@ -159,10 +159,15 @@ export class OPFSStorageProvider implements StorageProvider {
     const [parent, name] = await this.resolveParent(path, true);
     const fileHandle = await parent.getFileHandle(name, { create: true });
     const writable = await fileHandle.createWritable();
-    // FileSystemWritableFileStream accepts BufferSource directly; the cast
-    // widens Uint8Array<ArrayBufferLike> to satisfy TS expecting
-    // ArrayBufferView<ArrayBuffer>.
-    await writable.write(data as unknown as BufferSource);
+    // Copy partial views before writing: WebKit's write() ignores a view's
+    // byteOffset/byteLength and writes the entire underlying ArrayBuffer,
+    // corrupting the file. The cast widens Uint8Array<ArrayBufferLike> to
+    // satisfy TS expecting ArrayBufferView<ArrayBuffer>.
+    const chunk =
+      data.byteOffset === 0 && data.byteLength === data.buffer.byteLength
+        ? data
+        : data.slice();
+    await writable.write(chunk as unknown as BufferSource);
     await writable.close();
   }
 

--- a/packages/viola/src/client/sw-host.ts
+++ b/packages/viola/src/client/sw-host.ts
@@ -26,7 +26,10 @@ export function setupSwHost() {
       return;
     }
 
-    if (url.pathname.startsWith('/vivliostyle/')) {
+    if (
+      url.pathname.startsWith('/vivliostyle/') ||
+      url.pathname === '/@vivliostyle:viewer:client'
+    ) {
       return event.respondWith(handleRequest(event));
     }
   });

--- a/packages/viola/src/components/panes/new-project/project-detail-form.tsx
+++ b/packages/viola/src/components/panes/new-project/project-detail-form.tsx
@@ -48,7 +48,7 @@ function BookTitleInput({ children }: React.PropsWithChildren) {
     <label className="grid gap-2">
       {children}
       <div>
-        <Input type="text" name="bookTitle" required {...inputProps} />
+        <Input type="text" name="bookTitle" {...inputProps} />
       </div>
     </label>
   );
@@ -70,7 +70,7 @@ function AuthorInput({ children }: React.PropsWithChildren) {
     <label className="grid gap-2">
       {children}
       <div>
-        <Input type="text" name="author" required {...inputProps} />
+        <Input type="text" name="author" {...inputProps} />
       </div>
     </label>
   );
@@ -99,7 +99,6 @@ function LanguageSelect({ children }: React.PropsWithChildren) {
           <input
             type="text"
             name="language"
-            required
             value={snap.bibliography.language}
             tabIndex={-1}
             className="sr-only inset-0 size-auto pointer-events-none"

--- a/packages/viola/src/stores/actions/discover-projects.ts
+++ b/packages/viola/src/stores/actions/discover-projects.ts
@@ -39,16 +39,23 @@ async function readLocalEntry(
 }
 
 async function listLocalProjects(): Promise<ProjectEntry[]> {
-  const root = await OPFSStorageProvider.open();
-  const dirs = await root.list('');
-  const entries = await Promise.all(
-    dirs
-      .filter(
-        (entry) => entry.kind === 'directory' && entry.path !== draftProjectId,
-      )
-      .map((entry) => readLocalEntry(root, entry.path as ProjectId)),
-  );
-  return entries.filter((e): e is ProjectEntry => e !== null);
+  // OPFS can be unavailable (e.g. Safari private browsing rejects
+  // getDirectory); show an empty list instead of failing the route load.
+  try {
+    const root = await OPFSStorageProvider.open();
+    const dirs = await root.list('');
+    const entries = await Promise.all(
+      dirs
+        .filter(
+          (entry) =>
+            entry.kind === 'directory' && entry.path !== draftProjectId,
+        )
+        .map((entry) => readLocalEntry(root, entry.path as ProjectId)),
+    );
+    return entries.filter((e): e is ProjectEntry => e !== null);
+  } catch {
+    return [];
+  }
 }
 
 async function listRemoteProjects(): Promise<ProjectEntry[]> {

--- a/packages/viola/src/stores/actions/print-pdf.tsx
+++ b/packages/viola/src/stores/actions/print-pdf.tsx
@@ -26,7 +26,7 @@ export async function printPdf() {
   openedWindow.document.body.textContent = m.print_pdf_preparing();
   try {
     const cli = await $cli.awaiter();
-    const viewerUrl = await cli.createViewerUrlPromise();
+    const viewerUrl = await cli.createPrintViewerUrlPromise();
     if (openedWindow.closed || session !== printSession) {
       return;
     }

--- a/packages/viola/src/stores/actions/setup-project-from-draft.ts
+++ b/packages/viola/src/stores/actions/setup-project-from-draft.ts
@@ -1,3 +1,7 @@
+import {
+  DEFAULT_PROJECT_AUTHOR,
+  DEFAULT_PROJECT_TITLE,
+} from '@vivliostyle/cli/constants';
 import type { BuildTask } from '@vivliostyle/cli/schema';
 import { deepClone } from 'valtio/utils';
 
@@ -81,10 +85,12 @@ export async function setupProjectFromDraft({
       (await $$draftProject.theme.installPromise)?.packageName ??
       '@vivliostyle/theme-base';
 
+    // Empty values would send `vivliostyle create` into its interactive
+    // prompts, which never resolve inside the worker.
     await cli.setupTemplate({
-      title: $$draftProject.bibliography.title,
-      author: $$draftProject.bibliography.author,
-      language: $$draftProject.bibliography.language,
+      title: $$draftProject.bibliography.title || DEFAULT_PROJECT_TITLE,
+      author: $$draftProject.bibliography.author || DEFAULT_PROJECT_AUTHOR,
+      language: $$draftProject.bibliography.language || 'en',
       template: template.source,
       theme: themePackageName,
     });

--- a/packages/viola/src/stores/proxies/cli.ts
+++ b/packages/viola/src/stores/proxies/cli.ts
@@ -1,6 +1,7 @@
 import * as Comlink from 'comlink';
 import { proxy, ref } from 'valtio';
 
+import { appOrigin } from '../../libs/origins';
 import type { Sandbox } from './sandbox';
 
 export type RemoteCli = Comlink.Remote<typeof import('@v/cli-bundle')>;
@@ -15,6 +16,7 @@ export class Cli {
   protected sandbox: Sandbox;
   protected remoteDeferred: PromiseWithResolvers<RemoteCli> | undefined;
   protected lazyViewerUrlPromise: Promise<string> | undefined;
+  protected lazyPrintViewerUrlPromise: Promise<string> | undefined;
 
   protected constructor(sandbox: Sandbox) {
     this.sandbox = ref(sandbox);
@@ -36,6 +38,20 @@ export class Cli {
       return `${this.sandbox.iframeOrigin}/__vivliostyle-viewer/index.html#src=${this.sandbox.iframeOrigin}/vivliostyle/publication.json&bookMode=true&renderAllPages=true`;
     })();
     return this.lazyViewerUrlPromise;
+  }
+
+  // Viewer URL for the top-level print tab, served from the app origin. A
+  // top-level tab on the sandbox origin lives in its own storage partition,
+  // where the sandbox SW cannot reach the CLI worker over BroadcastChannel;
+  // the host SW instead relays requests through the host page (see
+  // `ProjectChannel`).
+  createPrintViewerUrlPromise() {
+    this.lazyPrintViewerUrlPromise ??= (async () => {
+      const remote = await this.createRemotePromise();
+      await remote.setupServer();
+      return `${appOrigin()}/_cli/viewer/index.html#src=${appOrigin()}/vivliostyle/publication.json&bookMode=true&renderAllPages=true`;
+    })();
+    return this.lazyPrintViewerUrlPromise;
   }
 
   createRemoteResolver() {
@@ -60,5 +76,6 @@ export class Cli {
     this.remoteDeferred?.reject(new Error('CLI remote disposed'));
     this.remoteDeferred = undefined;
     this.lazyViewerUrlPromise = undefined;
+    this.lazyPrintViewerUrlPromise = undefined;
   }
 }

--- a/packages/viola/src/stores/proxies/project.ts
+++ b/packages/viola/src/stores/proxies/project.ts
@@ -232,13 +232,16 @@ export class Project {
 }
 
 export interface ProjectChannel {
-  serve: (url: string, init: RequestInit) => Promise<[BodyInit, ResponseInit]>;
+  serve: (
+    url: string,
+    init: RequestInit,
+  ) => Promise<ConstructorParameters<typeof Response>>;
 }
 
 const channel = new BroadcastChannel('host:project');
 Comlink.expose(
   {
-    async serve(url: string, _init: RequestInit) {
+    async serve(url: string, init: RequestInit) {
       const { pathname } = new URL(url);
       const project =
         projects.currentProjectId && projects.value[projects.currentProjectId];
@@ -246,23 +249,34 @@ Comlink.expose(
         return ['', { status: 404 }];
       }
       const sandbox = await project.sandboxPromise;
-      const entryContext = sandbox.vivliostyleConfig.entryContext || '';
-      const filename = join(entryContext, relative('/vivliostyle', pathname));
-      const content = sandbox.files[filename];
-      if (!content) {
+      if (pathname.startsWith('/vivliostyle/')) {
+        const entryContext = sandbox.vivliostyleConfig.entryContext || '';
+        const filename = join(entryContext, relative('/vivliostyle', pathname));
+        const content = sandbox.files[filename];
+        if (content) {
+          const contentType = content.type || 'application/octet-stream';
+          return [
+            await content.buffer(),
+            {
+              status: 200,
+              headers: {
+                'Content-Type': contentType,
+                'Cache-Control': 'no-store',
+              },
+            },
+          ];
+        }
+      }
+      // Vite-generated resources (publication.json, entry HTML, the viewer
+      // client module) exist only in the CLI worker. The host-origin print tab
+      // reaches them through this relay because its own sandbox-origin SW sits
+      // in another storage partition and cannot see the worker.
+      try {
+        const cli = await sandbox.cli.createRemotePromise();
+        return await cli.serve(url, init);
+      } catch {
         return ['', { status: 404 }];
       }
-      const contentType = content.type || 'application/octet-stream';
-      return [
-        await content.buffer(),
-        {
-          status: 200,
-          headers: {
-            'Content-Type': contentType,
-            'Cache-Control': 'no-store',
-          },
-        },
-      ];
     },
   } satisfies ProjectChannel,
   channel,

--- a/packages/viola/src/stores/proxies/sandbox.ts
+++ b/packages/viola/src/stores/proxies/sandbox.ts
@@ -458,23 +458,32 @@ export class Sandbox {
   // writes the `files` subscriber kicks off (see `saveMemoryToFileSystem`).
   protected lastPersist: Promise<unknown> = Promise.resolve();
 
+  // Serializes overlapping batches: OPFS write streams take an exclusive
+  // per-file lock in Chromium, and two in-flight writes to the same path
+  // throw NoModificationAllowedError, silently dropping one of them.
+  protected persistQueue: Promise<unknown> = Promise.resolve();
+
   // Persist a set of changes in one shot, collapsing the per-file round-trips
   // into a single request on providers that support batching.
-  protected async persistChanges(
+  protected persistChanges(
     writes: { path: string; data: Uint8Array }[],
     deletes: string[],
   ) {
     if (writes.length === 0 && deletes.length === 0) {
-      return;
+      return Promise.resolve();
     }
-    if (this.provider.applyBatch) {
-      await this.provider.applyBatch({ writes, deletes });
-      return;
-    }
-    await Promise.all([
-      ...writes.map((write) => this.saveToFileSystem(write.path, write.data)),
-      ...deletes.map((path) => this.saveToFileSystem(path, null)),
-    ]);
+    const run = this.persistQueue.then(async () => {
+      if (this.provider.applyBatch) {
+        await this.provider.applyBatch({ writes, deletes });
+        return;
+      }
+      await Promise.all([
+        ...writes.map((write) => this.saveToFileSystem(write.path, write.data)),
+        ...deletes.map((path) => this.saveToFileSystem(path, null)),
+      ]);
+    });
+    this.persistQueue = run.catch(() => {});
+    return run;
   }
 
   protected async handleFileUpdate(ops: INTERNAL_Op[]) {


### PR DESCRIPTION
## Summary

alpha.vivliostyle.pub で確認された不具合の修正です。ヘッドレス Chrome / Firefox / WebKit (Playwright) で alpha に対する再現・原因特定を行いました。

### 1. Safari: プロジェクト再読込後に全ファイルが壊れる (`storage-providers`)
WebKit の `FileSystemWritableFileStream.write()` は Uint8Array ビューの byteOffset/byteLength を無視して**下層 ArrayBuffer 全体**を書き込みます（単体で再現確認済み: 100 バイトバッファの 10 バイトビューを書くと 100 バイトのファイルになる）。`saveMemoryToFileSystem` が CBOR スナップショットをデコードした FileNode data は巨大バッファへのビューなので、OPFS 上の全ファイルがスナップショット全体 (98KB) に置き換わり、再読込後に `vivliostyle.config.json` の JSON パースが `Unrecognized token '�'` で失敗していました。ビューが部分ビューの場合はコピーしてから書き込むようにし、回帰テストを追加しました。

### 2. Safari: プライベートブラウズでスタートページが真っ白 (`viola`)
`navigator.storage.getDirectory()` が `UnknownError` で reject すると `discoverProjects()` がルートの `beforeLoad` を落とし、メインペインが何も描画されませんでした。ローカル一覧を空扱いにして degrade するようにしました。

### 3. 全ブラウザ (デプロイ環境のみ): PDF 印刷が失敗 (`viola` / #67 のフォローアップ)
印刷タブはサンドボックスオリジンの**トップレベル**ページとして開くため、first-party (vspub.dev) のストレージパーティションに入ります。CLI ワーカーはホストページ配下の iframe (third-party パーティション) にあり、`BroadcastChannel('worker:cli')` はパーティション境界を越えられないため、SW の `serve()` が全てタイムアウトし `/@vivliostyle:viewer:client` と `/vivliostyle/publication.json` が 500 になっていました（ローカル開発ではサンドボックスがホストと same-site のため再現しません）。

印刷タブをアプリオリジン (`/_cli/viewer/index.html`) から配信するよう変更しました。ホスト SW → `host:project` リレー → (パーティションに依存しない MessagePort ブリッジ経由で) CLI ワーカーの `serve()` にフォールバックする経路を追加しています。

### 4. 全ブラウザ: EPUB / Web 出版物の書き出しが「Server is not ready」で失敗 (`cli-bundle`)
プレビューを一度も開いていないセッションでは Vite サーバーが未起動のまま `buildEpub`/`buildWebPub` が throw していました。`setupServer` をメモ化し、ビルド側から起動するようにしました。

### 5. 全ブラウザ: 新規プロジェクト作成が「すべて任意」のはずの空欄でブロックされる (`viola`)
書名・著者・言語の input に `required` が付いており、フォームの説明（すべての項目は任意）と矛盾してネイティブバリデーションで送信がブロックされていました。

## Test plan

- [x] `pnpm check` / `pnpm typecheck` / `pnpm build`
- [x] `@v/storage-providers` vitest (部分ビューコピーの回帰テスト追加)
- [x] `@v/cli-bundle` の成果物テスト
- [ ] PR プレビュー環境 (cross-site サンドボックス構成) で Chrome / Firefox / WebKit の E2E 再検証（プロジェクト作成 → 編集 → プレビュー → 印刷 → EPUB 書き出し、Safari は再読込後のファイル整合性）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9WGGkH6QhoAoS53viNtPj