### PR TITLE
fix(viola): stop non-owner tabs from answering host:project requests

### DIFF
--- a/packages/viola/src/client/sw-host.ts
+++ b/packages/viola/src/client/sw-host.ts
@@ -1,12 +1,12 @@
 /// <reference lib="webworker" />
 
-import * as Comlink from 'comlink';
-
-import type { ProjectChannel } from '../stores/proxies/project';
+import type {
+  ProjectServeRequest,
+  ProjectServeResponse,
+} from '../stores/proxies/project';
 import {
   buildRequestInit,
   createHeadResponse,
-  serveViaComlink,
   setupSwLifecycle,
 } from './sw-utils';
 
@@ -36,7 +36,52 @@ export function setupSwHost() {
 }
 
 const channel = new BroadcastChannel('host:project');
-const cli = Comlink.wrap<ProjectChannel>(channel);
+const pending = new Map<
+  string,
+  (result: ConstructorParameters<typeof Response>) => void
+>();
+channel.addEventListener('message', (event: MessageEvent) => {
+  const data = event.data as Partial<ProjectServeResponse> | undefined;
+  if (data?.type !== 'vs:project-serve-result' || !data.id || !data.result) {
+    return;
+  }
+  const resolve = pending.get(data.id);
+  if (resolve) {
+    pending.delete(data.id);
+    resolve(data.result);
+  }
+});
+
+// Broadcast the request to every tab; only the tab owning the requested
+// project replies (see `serveProjectResource`), so first-reply-wins is safe.
+async function serveViaProjectChannel(
+  url: string,
+  init: RequestInit,
+): Promise<Response> {
+  try {
+    const result = await new Promise<ConstructorParameters<typeof Response>>(
+      (resolve, reject) => {
+        const id = crypto.randomUUID();
+        pending.set(id, resolve);
+        setTimeout(() => {
+          if (pending.delete(id)) {
+            reject(new Error(`Request timeout: ${url}`));
+          }
+        }, 5000);
+        channel.postMessage({
+          type: 'vs:project-serve',
+          id,
+          url,
+          init,
+        } satisfies ProjectServeRequest);
+      },
+    );
+    return new Response(...result);
+  } catch (error) {
+    console.error(error);
+    return new Response('', { status: 500 });
+  }
+}
 
 async function handleRequest(event: FetchEvent) {
   const { request } = event;
@@ -44,5 +89,5 @@ async function handleRequest(event: FetchEvent) {
     return createHeadResponse();
   }
   const requestInit = await buildRequestInit(request);
-  return serveViaComlink(cli.serve, request.url, requestInit);
+  return serveViaProjectChannel(request.url, requestInit);
 }

--- a/packages/viola/src/stores/proxies/cli.ts
+++ b/packages/viola/src/stores/proxies/cli.ts
@@ -44,12 +44,13 @@ export class Cli {
   // top-level tab on the sandbox origin lives in its own storage partition,
   // where the sandbox SW cannot reach the CLI worker over BroadcastChannel;
   // the host SW instead relays requests through the host page (see
-  // `ProjectChannel`).
+  // `serveProjectResource`). The `/p/<projectId>/` prefix routes the request
+  // to the tab that owns this project.
   createPrintViewerUrlPromise() {
     this.lazyPrintViewerUrlPromise ??= (async () => {
       const remote = await this.createRemotePromise();
       await remote.setupServer();
-      return `${appOrigin()}/_cli/viewer/index.html#src=${appOrigin()}/vivliostyle/publication.json&bookMode=true&renderAllPages=true`;
+      return `${appOrigin()}/_cli/viewer/index.html#src=${appOrigin()}/vivliostyle/p/${this.sandbox.projectId}/publication.json&bookMode=true&renderAllPages=true`;
     })();
     return this.lazyPrintViewerUrlPromise;
   }

--- a/packages/viola/src/stores/proxies/project.ts
+++ b/packages/viola/src/stores/proxies/project.ts
@@ -1,5 +1,4 @@
 import { LANGUAGES } from '@vivliostyle/cli/constants';
-import * as Comlink from 'comlink';
 import { join, relative } from 'pathe';
 import { proxy, ref, subscribe } from 'valtio';
 import { deepClone } from 'valtio/utils';
@@ -231,53 +230,97 @@ export class Project {
   }
 }
 
-export interface ProjectChannel {
-  serve: (
-    url: string,
-    init: RequestInit,
-  ) => Promise<ConstructorParameters<typeof Response>>;
+export interface ProjectServeRequest {
+  type: 'vs:project-serve';
+  id: string;
+  url: string;
+  init: RequestInit;
 }
 
+export interface ProjectServeResponse {
+  type: 'vs:project-serve-result';
+  id: string;
+  result: ConstructorParameters<typeof Response>;
+}
+
+// Requests may address a specific project as `/vivliostyle/p/<projectId>/...`
+// (the print tab does); the owning tab strips the prefix before serving.
+const projectPathRe = /^\/vivliostyle\/p\/([a-z0-9]+)(\/.*)$/;
+
+// Returns null when this tab is not responsible for the request, so another
+// tab's relay can answer instead.
+async function serveProjectResource(
+  url: string,
+  init: RequestInit,
+): Promise<ConstructorParameters<typeof Response> | null> {
+  const target = new URL(url);
+  const project =
+    projects.currentProjectId && projects.value[projects.currentProjectId];
+  if (!project) {
+    return null;
+  }
+  const prefixed = target.pathname.match(projectPathRe);
+  if (prefixed) {
+    if (prefixed[1] !== projects.currentProjectId) {
+      return null;
+    }
+    target.pathname = `/vivliostyle${prefixed[2]}`;
+  }
+  const sandbox = await project.sandboxPromise;
+  if (target.pathname.startsWith('/vivliostyle/')) {
+    const entryContext = sandbox.vivliostyleConfig.entryContext || '';
+    const filename = join(
+      entryContext,
+      relative('/vivliostyle', target.pathname),
+    );
+    const content = sandbox.files[filename];
+    if (content) {
+      const contentType = content.type || 'application/octet-stream';
+      return [
+        await content.buffer(),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': contentType,
+            'Cache-Control': 'no-store',
+          },
+        },
+      ];
+    }
+  }
+  // Vite-generated resources (publication.json, entry HTML, the viewer
+  // client module) exist only in the CLI worker. The host-origin print tab
+  // reaches them through this relay because its own sandbox-origin SW sits
+  // in another storage partition and cannot see the worker.
+  try {
+    const cli = await sandbox.cli.createRemotePromise();
+    return await cli.serve(target.href, init);
+  } catch {
+    return ['', { status: 404 }];
+  }
+}
+
+// Hand-rolled RPC instead of Comlink: every tab shares this BroadcastChannel,
+// and Comlink.expose would make all of them answer every request — a tab
+// without the project instantly wins the race with a 404. Here tabs stay
+// silent unless they own the requested project.
 const channel = new BroadcastChannel('host:project');
-Comlink.expose(
-  {
-    async serve(url: string, init: RequestInit) {
-      const { pathname } = new URL(url);
-      const project =
-        projects.currentProjectId && projects.value[projects.currentProjectId];
-      if (!project) {
-        return ['', { status: 404 }];
-      }
-      const sandbox = await project.sandboxPromise;
-      if (pathname.startsWith('/vivliostyle/')) {
-        const entryContext = sandbox.vivliostyleConfig.entryContext || '';
-        const filename = join(entryContext, relative('/vivliostyle', pathname));
-        const content = sandbox.files[filename];
-        if (content) {
-          const contentType = content.type || 'application/octet-stream';
-          return [
-            await content.buffer(),
-            {
-              status: 200,
-              headers: {
-                'Content-Type': contentType,
-                'Cache-Control': 'no-store',
-              },
-            },
-          ];
-        }
-      }
-      // Vite-generated resources (publication.json, entry HTML, the viewer
-      // client module) exist only in the CLI worker. The host-origin print tab
-      // reaches them through this relay because its own sandbox-origin SW sits
-      // in another storage partition and cannot see the worker.
-      try {
-        const cli = await sandbox.cli.createRemotePromise();
-        return await cli.serve(url, init);
-      } catch {
-        return ['', { status: 404 }];
-      }
-    },
-  } satisfies ProjectChannel,
-  channel,
-);
+channel.addEventListener('message', async (event: MessageEvent) => {
+  const data = event.data as Partial<ProjectServeRequest> | undefined;
+  if (data?.type !== 'vs:project-serve' || !data.id || !data.url) {
+    return;
+  }
+  try {
+    const result = await serveProjectResource(data.url, data.init ?? {});
+    if (!result) {
+      return;
+    }
+    channel.postMessage({
+      type: 'vs:project-serve-result',
+      id: data.id,
+      result,
+    } satisfies ProjectServeResponse);
+  } catch {
+    // No reply; the service worker times the request out.
+  }
+});

--- a/packages/viola/src/stores/proxies/sandbox.ts
+++ b/packages/viola/src/stores/proxies/sandbox.ts
@@ -263,6 +263,7 @@ export class Sandbox {
     return MIME_BY_EXT[ext.toLowerCase()];
   }
 
+  projectId: ProjectId;
   iframeOrigin: string;
   provider: StorageProvider;
   files: Record<string, ReturnType<typeof ref<SandboxFile>>> = proxy({});
@@ -283,6 +284,7 @@ export class Sandbox {
     projectId: ProjectId;
     provider: StorageProvider;
   }) {
+    this.projectId = projectId;
     this.iframeOrigin = sandboxOrigin(`sandbox-${projectId}`);
     this.provider = ref(provider);
   }


### PR DESCRIPTION
## Summary

#71 デプロイ後の alpha で、別タブを開いた状態で「PDFを印刷」を実行すると印刷タブが `Failed to fetch required resource: .../vivliostyle/publication.json (404)` になる問題の修正です。

### 原因

`host:project` チャンネルのリレーは `Comlink.expose` を共有 `BroadcastChannel` 上で行っており、**Comlink は聞こえた全リクエストに必ず応答**します。そのため alpha を開いている全タブがサービスワーカーの `serve()` 呼び出しに応答し、SW は最初に届いた応答を採用します。プロジェクトを開いていないタブ（スタートページ等）は仕事をせず即座に `['', {status: 404}]` を返すため、正しいエディタタブの応答にほぼ確実に勝ってしまい、印刷タブへの配信が 404 になります。

再現確認済み: alpha でエディタタブ単独なら印刷成功、スタートページを別タブで開くと `publication.json` / `@vivliostyle:viewer:client` が 404（ユーザー報告と同一のエラー）。

### 修正

- Comlink をやめ、`host:project` 上に最小の request/response プロトコルを実装。**担当外のタブは応答せず沈黙**し（Comlink では不可能）、SW は最初の応答を採用（5 秒タイムアウトで 500）。
- 印刷タブの viewer `src` を `/vivliostyle/p/<projectId>/publication.json` に変更し、リクエストの担当タブを決定的に。所有タブがプレフィックスを剥がして従来どおり配信します（マニフェスト相対の子リソースも同プレフィックス配下に解決される）。
- `Sandbox` に `projectId` を保持（印刷 URL 構築用）。

### 注意点

- SW とページのプロトコルが変わるため、デプロイ直後に「旧ページ + 新 SW」（またはその逆）の組み合わせになった既存セッションでは、エディタ内アセット配信が一時的にタイムアウト (500) になることがあります。`skipWaiting`/`clients.claim` と通常のリロードで解消する過渡的なものです。

## Test plan

- [x] `pnpm check` / `pnpm typecheck` / viola build
- [x] ローカル dev で**マルチタブ**印刷（スタートページを別タブに開いた状態）: 印刷タブが 404 なしで完走、`publication.json` → 200
- [x] 単一タブ回帰 (Chrome / Firefox): 作成 → 編集 → 印刷（`/p/<projectId>/` URL で viewer 完走）→ EPUB 書き出し
- [ ] alpha デプロイ後、複数タブを開いた状態で「PDFを印刷」を実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9WGGkH6QhoAoS53viNtPj