### PR TITLE
feat(extension-kit): add apiFetch host API for authenticated server requests

### DIFF
--- a/packages/extension-kit/src/index.ts
+++ b/packages/extension-kit/src/index.ts
@@ -71,11 +71,34 @@ export type ExtensionSessionListener = (
  *   - `session:write` → `login`, `register`, `logout`, `applyBearerSession`,
  *                       `clearBearerSession`, `startProviderSignIn`
  *   - `viewer:read`   → `getViewerUrl`
+ *   - `api:request`   → `apiFetch`
  */
 export type ExtensionPermission =
   | 'session:read'
   | 'session:write'
-  | 'viewer:read';
+  | 'viewer:read'
+  | 'api:request';
+
+/** Request shape for {@link ExtensionHostApi.apiFetch}. */
+export interface ExtensionApiRequestInit {
+  method?: string;
+  headers?: Record<string, string>;
+  /** Request body; for the project API this is a JSON string. */
+  body?: string;
+}
+
+/**
+ * Response from {@link ExtensionHostApi.apiFetch}. The body is returned as raw
+ * bytes so the same call serves both JSON endpoints (decode with `TextDecoder`)
+ * and binary downloads (use the `ArrayBuffer` directly); a `Response`/`Headers`
+ * pair would not survive Comlink's structured clone.
+ */
+export interface ExtensionApiResponse {
+  ok: boolean;
+  status: number;
+  headers: Record<string, string>;
+  body: ArrayBuffer;
+}
 
 /**
  * Capabilities the host exposes to an extension view over Comlink.
@@ -100,6 +123,17 @@ export interface ExtensionHostApi {
   startProviderSignIn(provider: string): Promise<void>;
   getLocale(): string;
   getViewerUrl(): Promise<string>;
+  /**
+   * Make an authenticated request to the connected API server. `path` is
+   * resolved against the session's server base URL, and the host attaches the
+   * signed-in user's bearer token — the token itself never enters the extension
+   * sandbox. Lets an extension call server endpoints (its own or the core ones)
+   * on behalf of the current user.
+   */
+  apiFetch(
+    path: string,
+    init?: ExtensionApiRequestInit,
+  ): Promise<ExtensionApiResponse>;
 }
 
 /** The host API as seen from inside the iframe (Comlink-proxied). */

--- a/packages/viola/src/components/panes/pane.extension.tsx
+++ b/packages/viola/src/components/panes/pane.extension.tsx
@@ -133,6 +133,26 @@ const hostApiRegistry: HostApiRegistry = {
       return await cli.createViewerUrlPromise();
     },
   },
+  apiFetch: {
+    permission: 'api:request',
+    impl: async (path, init) => {
+      const token = await $session.auth.getAccessToken();
+      const res = await fetch(`${$session.baseUrl}${path}`, {
+        method: init?.method ?? 'GET',
+        headers: {
+          ...init?.headers,
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: init?.body,
+      });
+      const body = await res.arrayBuffer();
+      const headers: Record<string, string> = {};
+      res.headers.forEach((value, key) => {
+        headers[key] = value;
+      });
+      return { ok: res.ok, status: res.status, headers, body };
+    },
+  },
 };
 
 function denyPermission(

--- a/packages/viola/src/libs/awaiter.ts
+++ b/packages/viola/src/libs/awaiter.ts
@@ -28,7 +28,10 @@ export const awaiter = async <T>({
         // timeout
         return reject(new Error(`Awaiter timeout: ${name}`));
       }
-      requestAnimationFrame(loop);
+      // Poll via setTimeout, not requestAnimationFrame: rAF is paused while the
+      // document is hidden, which would stall this loop — and its timeout — until
+      // the tab is shown again.
+      setTimeout(loop, 50);
     };
     loop();
   });

--- a/packages/viola/src/stores/proxies/sandbox.ts
+++ b/packages/viola/src/stores/proxies/sandbox.ts
@@ -436,8 +436,12 @@ export class Sandbox {
       }
     };
     traverse(rootNode);
-    // Let the `files` subscriber fire, then await the persistence it started.
-    await new Promise((resolve) => window.requestAnimationFrame(resolve));
+    // Yield a macrotask so the `files` subscriber (valtio batches it onto a
+    // microtask) runs and sets `lastPersist`, then await it. Uses `setTimeout`
+    // rather than `requestAnimationFrame`: rAF is paused while the tab is hidden,
+    // so it would never fire — hanging this save, and thus project creation, in a
+    // background tab.
+    await new Promise((resolve) => setTimeout(resolve));
     await this.lastPersist;
   }
 


### PR DESCRIPTION
## What

Adds a new `apiFetch` capability to the extension host API, letting an extension view make authenticated requests to the connected API server without ever handling the user's credentials itself.

- **`extension-kit`**: introduces the `api:request` permission and the `apiFetch(path, init?)` method on `ExtensionHostApi`, along with `ExtensionApiRequestInit` and `ExtensionApiResponse` types. The response body is returned as raw `ArrayBuffer` bytes so a single call shape serves both JSON endpoints (decode with `TextDecoder`) and binary downloads — a `Response`/`Headers` pair would not survive Comlink's structured clone.
- **`viola`**: implements `apiFetch` in the extension pane's host API registry, gated behind the `api:request` permission. The host resolves `path` against the session's server base URL and attaches the signed-in user's bearer token on the host side, so the token never enters the extension sandbox.

Also fixes two polling/yield points that used `requestAnimationFrame`:

- `libs/awaiter.ts` now polls with `setTimeout` instead of `requestAnimationFrame`. rAF is paused while the document is hidden, which stalled the wait loop — and its timeout — until the tab was shown again.
- `stores/proxies/sandbox.ts` yields a macrotask via `setTimeout` (instead of rAF) before awaiting persistence, so saving — and thus project creation — no longer hangs in a background tab.

## Why

Extensions can now call server endpoints (their own or the core ones) on behalf of the current user through an explicit, permission-gated channel, and async flows that relied on rAF no longer freeze when the tab is hidden.