### PR TITLE
fix(tiptap-extensions): ignore YAML frontmatter when parsing markdown

### DIFF
--- a/packages/tiptap-extensions/src/frontmatter.ts
+++ b/packages/tiptap-extensions/src/frontmatter.ts
@@ -1,7 +1,11 @@
 import { Extension } from '@tiptap/core';
 
+// Mirrors VFM (remark-frontmatter): blank lines before the opening fence are
+// allowed, the opening fence must be exactly `---` on its own line, and the
+// closing fence is the first subsequent line starting with `---` (anything
+// after those dashes is left in the source, as VFM does).
 const FRONTMATTER_RE =
-  /^---[ \t]*\r?\n(?:[\s\S]*?\r?\n)?---[ \t]*(?:(?:\r?\n)+|$)/;
+  /^(?:[ \t]*\r?\n)*---\r?\n(?:[\s\S]*?\r?\n)?---(?:(?:[ \t]*\r?\n)+|[ \t]*$)?/;
 
 /**
  * Consumes a leading YAML frontmatter block as a single token so marked does

--- a/packages/tiptap-extensions/src/frontmatter.ts
+++ b/packages/tiptap-extensions/src/frontmatter.ts
@@ -1,0 +1,34 @@
+import { Extension } from '@tiptap/core';
+
+const FRONTMATTER_RE =
+  /^---[ \t]*\r?\n(?:[\s\S]*?\r?\n)?---[ \t]*(?:(?:\r?\n)+|$)/;
+
+/**
+ * Consumes a leading YAML frontmatter block as a single token so marked does
+ * not misread it as a thematic break followed by a setext heading. No
+ * `parseMarkdown` handler is registered, so the token produces no editor node
+ * and the frontmatter is dropped from the document.
+ */
+export const Frontmatter = Extension.create({
+  name: 'frontmatter',
+
+  markdownTokenizer: {
+    name: 'frontmatter',
+    level: 'block',
+    // Frontmatter can never start mid-document, so it must not take part in
+    // marked's paragraph-interruption checks.
+    start: () => -1,
+    tokenize(src, tokens) {
+      // tokens accumulates previously lexed blocks, so a non-empty array means
+      // we are past the start of the document (or of a nested block).
+      if (tokens.length > 0) {
+        return undefined;
+      }
+      const match = src.match(FRONTMATTER_RE);
+      if (!match) {
+        return undefined;
+      }
+      return { type: 'frontmatter', raw: match[0] };
+    },
+  },
+});

--- a/packages/tiptap-extensions/src/index.ts
+++ b/packages/tiptap-extensions/src/index.ts
@@ -25,6 +25,7 @@ import {
   type CustomDragPayload,
 } from './custom-drag-handler';
 import { FileMediaHandler } from './file-media-handler';
+import { Frontmatter } from './frontmatter';
 
 export {
   type AssetDragPayload,
@@ -140,6 +141,7 @@ export const PubExtensions = Extension.create<PubExtensionConfig>({
         },
       }).configure({}),
       Markdown.configure({}),
+      Frontmatter,
     ];
   },
 });


### PR DESCRIPTION
#73

## Summary

marked (used by `@tiptap/markdown`) has no frontmatter support, so opening a markdown file that starts with a YAML frontmatter block rendered it in the rich editor as a horizontal rule followed by a setext heading of the metadata text.

- Add a `Frontmatter` extension to `@v/tiptap-extensions` that registers a marked block tokenizer consuming a leading frontmatter block as a single token; with no parse handler registered, the token produces no editor node and the frontmatter is dropped from the document
- The tokenizer only matches at the very start of the document (`tokens.length === 0`) and opts out of marked's paragraph-interruption checks (`start: () => -1`), so `---` elsewhere still parses as a thematic break / setext heading
- Register the extension in `PubExtensions`, covering both the app editor and the debug AST viewer

Interpreting (and round-trip preserving) the frontmatter contents is intentionally out of scope for now — the block is simply ignored on load.

## Verification

Checked on `/debug/ast-viewer` with the dev server:

- Frontmatter-only document → editor doc is a single empty paragraph (previously hr + heading "title: foo")
- Frontmatter + body → only the body is parsed, no leading empty paragraph
- Mid-document `---` → still `horizontalRule`; `foo\n---` → still a level-2 setext heading
- `pnpm typecheck` / biome pass, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5HHVtsNDnSPghiUGbcjCd